### PR TITLE
Fix UI quirks

### DIFF
--- a/src/RootNavigator.tsx
+++ b/src/RootNavigator.tsx
@@ -101,6 +101,9 @@ export default React.memo(function RootNavigator() {
                 headerLeft: () => (
                   <MenuButton />
                 ),
+                cardStyle: {
+                  maxHeight: "100%",
+                },
               }}
             />
             <Stack.Screen

--- a/src/screens/NoteListScreen.tsx
+++ b/src/screens/NoteListScreen.tsx
@@ -170,6 +170,7 @@ export default function NoteListScreen(props: PropsType) {
         onDismiss={() => setNewItemDialogShow(false)}
       />
       <FAB
+        visible={!newItemDialogShow}
         icon="plus"
         accessibilityLabel="New"
         color="white"


### PR DESCRIPTION
Small improvements:

- Hide FAB when `NoteEditDialog` is visible: fixes #48 (or maybe [a more durable solution](https://github.com/callstack/react-native-paper/issues/1668#issuecomment-586005762) would be better?).
- Set `maxHeight` on the Home screen to keep the FAB in place on web: fixes #52 according to [this comment](https://github.com/etesync/etesync-notes/issues/52#issuecomment-731756620).

Tested on Web and Android