### PR TITLE
Add Checkboxes Preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "expo-updates": "~0.3.2",
     "immutable": "^4.0.0-rc.12",
     "localforage": "^1.9.0",
+    "markdown-it-task-checkbox": "^1.0.6",
     "moment": "^2.29.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/src/widgets/Markdown.tsx
+++ b/src/widgets/Markdown.tsx
@@ -2,9 +2,69 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as React from "react";
-import { Linking } from "react-native";
-import { useTheme } from "react-native-paper";
-import MarkdownDisplay from "react-native-markdown-display";
+import { Linking, StyleSheet, View } from "react-native";
+import { Checkbox, Text, TouchableRipple, useTheme } from "react-native-paper";
+import MarkdownDisplay, { MarkdownIt, renderRules, RenderRules } from "react-native-markdown-display";
+import TaskCheckbox from "markdown-it-task-checkbox";
+
+const rules: RenderRules = {
+  label: (node, _children, _parent, _styles) => 
+    <Text
+      key={node.key}
+      style={defaultStyles.label}
+    >
+      {node.children[0].content}
+    </Text>
+  ,
+  checkbox_input: (node, _children, _parent, _styles) => 
+    <Checkbox.Android
+      key={node.key}
+      status={node.attributes.checked === "true" ? "checked" : "unchecked"}
+      disabled
+    />,
+  list_item: (node, children, parent, styles, inheritedStyles) => {
+    if (node.attributes.class === "task-list-item") {
+      return (
+        <TouchableRipple key={node.key}>
+          <View style={defaultStyles.container} pointerEvents="none">
+            {children}
+          </View>
+        </TouchableRipple>
+      );
+    } else if (renderRules.list_item != null) {
+      return renderRules.list_item(node, children, parent, styles, inheritedStyles);
+    } else {
+      return null;
+    }
+  },
+  textgroup: (node, children, parent, styles) => {
+    const list = parent.find((p) => p.type === "bullet_list");
+    if (list != null && list.attributes.class === "task-list") {
+      return (
+        <React.Fragment key={node.key}>
+          {children}
+        </React.Fragment>
+      );
+    } else if (renderRules.textgroup != null) {
+      return renderRules.textgroup(node, children, parent, styles);
+    } else {
+      return null;
+    }
+  },
+};
+
+const defaultStyles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-start",
+  },
+  label: {
+    fontSize: 16,
+  },
+});
+
+const markdownItInstance = MarkdownIt().use(TaskCheckbox);
 
 const Markdown = React.memo(function _Markdown(props: { content: string }) {
   const theme = useTheme();
@@ -13,6 +73,8 @@ const Markdown = React.memo(function _Markdown(props: { content: string }) {
 
   return (
     <MarkdownDisplay
+      markdownit={markdownItInstance}
+      rules={rules}
       style={{
         body: { color: theme.colors.text },
         link: { color: theme.colors.accent, textDecorationLine: "underline" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6144,6 +6144,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it-task-checkbox@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/markdown-it-task-checkbox/-/markdown-it-task-checkbox-1.0.6.tgz#9ebd7b6382e99162264605bc580f2ac118be4242"
+  integrity sha512-7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw==
+
 markdown-it@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-10.0.0.tgz#abfc64f141b1722d663402044e43927f1f50a8dc"


### PR DESCRIPTION
Add support for Checkboxes in Markdown.  This is the first step in #35 

![Screenshot_20201220-214308](https://user-images.githubusercontent.com/76261501/102724486-1e310980-4310-11eb-902e-6b41dfa4c66e.png)

There is a slight alignment issue between the checkbox and the text on the Web version on Firefox, but it's almost imperceptible on Chromium, so I guess that'll do.
![Capture d’écran de 2020-12-20 22-02-10](https://user-images.githubusercontent.com/76261501/102724342-2fc5e180-430f-11eb-8b49-ca000c8a7aaf.png)

To be able to toggle the checkboxes from preview is gonna take a lot of extra work (to have a good solution and not a hack). Two options I thought of:
- Associate the checkbox with the proper line in the text, meaning make the parser to store extra data in the AST tree.
- Make a change in the AST tree and regenerate Markdown from it. That would sanitize the Markdown so we have to make sure we don't lose anything. Also, there doesn't seem to be a *stringifier* for markdown-it so we'd need to use another parser like remark, which means we'd probably have to implement our components ourselves.

 It's probably gonna be simpler with the rich text editor. For example [rich-markdown-editor](https://www.npmjs.com/package/rich-markdown-editor) allows us to enable checkboxes even in read-only mode. That would mean no native components.

Tested on Android and Web.