### PR TITLE
Make checkboxes interactive in preview

### DIFF
--- a/src/screens/ItemEditScreen.tsx
+++ b/src/screens/ItemEditScreen.tsx
@@ -176,6 +176,7 @@ export default function ItemEditScreen(props: PropsType) {
       {viewMode ? (
         <ScrollView keyboardAware contentContainerStyle={{ flexGrow: 1, padding: 10 }}>
           <Markdown
+            setContent={setContent}
             content={content}
           />
         </ScrollView>

--- a/src/widgets/Markdown/markdown-it-tasklist.ts
+++ b/src/widgets/Markdown/markdown-it-tasklist.ts
@@ -66,10 +66,15 @@ const markdownItTasklist: MarkdownIt.PluginSimple = function (md) {
         if (token.children != null) {
           token.children[0].content = token.children[0].content.slice(3);
         }
-        // list_item ancestor
-        attrSet(tokens[i - 2], "class", "task-list-item");
-        attrSet(tokens[i - 2], "checked", checked ? "true" : "false");
-        // bullet_list ancestor
+        // list_item_open ancestor
+        const li = tokens[i - 2];
+        attrSet(li, "class", "task-list-item");
+        attrSet(li, "checked", checked ? "true" : "false");
+        if (li.map != null) {
+          attrSet(li, "startline", li.map[0].toString());
+          attrSet(li, "endline", li.map[1].toString());
+        }
+        // bullet_list_open ancestor
         attrSet(tokens[parentToken(tokens, i - 2)], "class", "task-list");
       }
     }

--- a/src/widgets/Markdown/toggle-checkbox.ts
+++ b/src/widgets/Markdown/toggle-checkbox.ts
@@ -1,0 +1,62 @@
+const CHECKED_REGEX = /- \[x\]/i;
+const UNCHECKED_REGEX = /- \[ \]/;
+
+export default function toggleCheckbox(
+  content: string,
+  startline: string,
+  endline: string,
+  setContent: (value: string) => void
+): void {
+  const sl = parseInt(startline);
+  const el = parseInt(endline);
+
+  // Split into lines
+  const arr = content.split("\n");
+  const parentTask = arr[sl];
+
+  // See if the (first) checkbox in the start line is checked or unchecked
+  // to determine the state of all the group
+  const checkedIndex = parentTask.search(CHECKED_REGEX);
+  const uncheckedIndex = parentTask.search(UNCHECKED_REGEX);
+  const checked =
+    uncheckedIndex === -1 ||
+    (checkedIndex !== -1 && checkedIndex < uncheckedIndex);
+
+  // Get the start and end position of the checkbox range
+  const len = content.length;
+  let line = 0;
+  let pos = 0;
+  let startPos = 0;
+  let endPos = 0;
+  while (pos < len && line < el) {
+    const ch = content.charCodeAt(pos);
+
+    if (ch === 0x0a || pos === len - 1) {
+      line++;
+
+      if (line === sl) {
+        startPos = pos + 1;
+      } else if (line === el) {
+        endPos = pos;
+      }
+    }
+
+    pos++;
+  }
+
+  // Extract the different parts for the new content
+  const before = content.slice(0, startPos);
+  const toChange = content.slice(startPos, endPos).split("\n");
+  const after = content.slice(endPos);
+
+  // Change the checkbox(es)
+  toChange.forEach((s, i, arr) => {
+    if (checked) {
+      arr[i] = s.replace(CHECKED_REGEX, "- [ ]");
+    } else {
+      arr[i] = s.replace(UNCHECKED_REGEX, "- [x]");
+    }
+  });
+
+  setContent(before + toChange.join("\n") + after);
+}


### PR DESCRIPTION
Everything is in the title.

Gotchas:
  - All the preview is rerendered when the checkbox value changes due to a limitation in `react-native-markdown-display` that generates new keys each time the content is parsed.
  - This results in an "intro" effect on all the checkboxes of the view.
  - All the box is pressable (including the background on the left of the nested children). The ripple effect occurs over the whole region.

This fixes #35 