### PR TITLE
Set up linking for web

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,33 @@ enableScreens();
 
 const DrawerNavigation = createDrawerNavigator();
 
+const linking = {
+  prefixes: ["https://notes.etesync.com", "com.etesync.notes://"],
+  config: {
+    screens: {
+      Root: {
+        path: "",
+        screens: {
+          home: "notes/:colUid?",
+          LoginScreen: "login",
+          Signup: "signup",
+          CollectionCreate: "notes/new-notebook",
+          CollectionEdit: "notes/:colUid/edit",
+          CollectionChangelog: "notes/:colUid/manage",
+          CollectionMembers: "notes/:colUid/members",
+          ItemEdit: "notes/:colUid/:itemUid",
+          Invitations: "invitations",
+          Settings: "settings",
+          About: "settings/about",
+          DebugLogs: "settings/logs",
+          AccountWizard: "account-wizard",
+          "404": "*",
+        },
+      },
+    },
+  },
+};
+
 function InnerApp() {
   // XXX Workaround for react-navigation #7561 (flashing drawer)
   const [initRender, setInitRender] = React.useState(true);
@@ -46,7 +73,7 @@ function InnerApp() {
     <PaperProvider theme={theme}>
       <ErrorBoundary>
         <SettingsGate>
-          <NavigationContainer>
+          <NavigationContainer linking={linking}>
             <DrawerNavigation.Navigator
               drawerContent={({ navigation }) => <Drawer navigation={navigation} />}
               drawerStyle={initRender ? { width: 0 } : null}

--- a/src/Drawer.tsx
+++ b/src/Drawer.tsx
@@ -123,7 +123,7 @@ export default function Drawer(props: PropsType) {
               title="All Notes"
               onPress={() => {
                 navigation.closeDrawer();
-                navigation.navigate("home", { colUid: undefined });
+                navigation.navigate("home", { colUid: "" });
               }}
               left={(props) => <List.Icon {...props} icon="note-multiple" />}
             />
@@ -143,7 +143,7 @@ export default function Drawer(props: PropsType) {
               <List.Item
                 title="Create new notebook"
                 onPress={() => {
-                  navigation.navigate("CollectionEdit", {});
+                  navigation.navigate("CollectionCreate");
                 }}
                 left={(props) => <List.Icon {...props} icon="plus" />}
               />

--- a/src/RootNavigator.tsx
+++ b/src/RootNavigator.tsx
@@ -22,6 +22,7 @@ import CollectionChangelogScreen from "./screens/CollectionChangelogScreen";
 import CollectionMembersScreen from "./screens/CollectionMembersScreen";
 import InvitationsScreen from "./screens/InvitationsScreen";
 import AccountWizardScreen from "./screens/AccountWizardScreen";
+import NotFoundScreen from "./screens/NotFoundScreen";
 
 import { useCredentials } from "./credentials";
 import { performSync, popMessage } from "./store/actions";
@@ -111,6 +112,10 @@ export default React.memo(function RootNavigator() {
               component={CollectionEditScreen}
             />
             <Stack.Screen
+              name="CollectionCreate"
+              component={CollectionEditScreen}
+            />
+            <Stack.Screen
               name="CollectionChangelog"
               component={CollectionChangelogScreen}
               options={{
@@ -152,6 +157,16 @@ export default React.memo(function RootNavigator() {
           component={AccountWizardScreen}
           options={{
             title: C.appName,
+          }}
+        />
+        <Stack.Screen
+          name="404"
+          component={NotFoundScreen}
+          options={{
+            title: "Page Not Found",
+            headerLeft: () => (
+              <MenuButton />
+            ),
           }}
         />
       </Stack.Navigator>

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -4,6 +4,7 @@
 import * as React from "react";
 import { AppState, AppStateStatus } from "react-native";
 import * as Etebase from "etebase";
+import { NavigationProp } from "@react-navigation/native";
 
 import { logger } from "./logging";
 
@@ -151,4 +152,12 @@ export function enforcePasswordRules(password: string): string | undefined {
     return `Passwourds should be at least ${PASSWORD_MIN_LENGTH} digits long.`;
   }
   return undefined;
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function navigateTo404(navigation: NavigationProp<Record<string, object | undefined>>, title = "Notebook not found", message = "This notebook can't be found") {
+  navigation.navigate("404", {
+    title,
+    message,
+  });
 }

--- a/src/screens/CollectionChangelogScreen.tsx
+++ b/src/screens/CollectionChangelogScreen.tsx
@@ -15,7 +15,7 @@ import Container from "../widgets/Container";
 import Menu from "../widgets/Menu";
 import { Title } from "../widgets/Typography";
 
-import { defaultColor } from "../helpers";
+import { defaultColor, navigateTo404 } from "../helpers";
 
 import ColorBox from "../widgets/ColorBox";
 
@@ -55,9 +55,9 @@ export default function CollectionChangelogScreen(props: PropsType) {
     return syncGate;
   }
 
-
   if (!cachedCollection || !colCachedItems) {
-    return <Text>Error</Text>;
+    navigateTo404(navigation);
+    return null;
   }
 
   const { meta } = cachedCollection;

--- a/src/screens/CollectionEditScreen.tsx
+++ b/src/screens/CollectionEditScreen.tsx
@@ -19,7 +19,7 @@ import Container from "../widgets/Container";
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import ErrorOrLoadingDialog from "../widgets/ErrorOrLoadingDialog";
 
-import { useLoading, defaultColor } from "../helpers";
+import { useLoading, defaultColor, navigateTo404 } from "../helpers";
 
 import ColorPicker from "../widgets/ColorPicker";
 import * as C from "../constants";
@@ -52,7 +52,7 @@ export default function CollectionEditScreen(props: PropsType) {
   const [loading, error, setPromise] = useLoading();
   const colType = C.colType;
 
-  const colUid: string = props.route.params.colUid ?? "";
+  const colUid: string = props.route.params?.colUid ?? "";
   React.useEffect(() => {
     if (syncGate) {
       return;
@@ -66,6 +66,8 @@ export default function CollectionEditScreen(props: PropsType) {
       if (meta.color !== undefined) {
         setColor(meta.color);
       }
+    } else if (colUid.length > 0) {
+      navigateTo404(navigation);
     }
 
   }, [syncGate, colUid]);

--- a/src/screens/CollectionMembersScreen.tsx
+++ b/src/screens/CollectionMembersScreen.tsx
@@ -19,6 +19,7 @@ import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import ErrorDialog from "../widgets/ErrorDialog";
 import CollectionMemberAddDialog from "../components/CollectionMemberAddDialog";
 import { pushMessage } from "../store/actions";
+import { navigateTo404 } from "../helpers";
 
 type RootStackParamList = {
   CollectionMembersScreen: {
@@ -46,11 +47,17 @@ export default function CollectionMembersScreen(props: PropsType) {
 
   const revokeUserIsAdmin = revokeUser?.accessLevel === Etebase.CollectionAccessLevel.Admin;
 
-  const { colUid } = props.route.params;
+  const colUid = props.route.params?.colUid ?? "";
+  const cacheCollection = collections.get(colUid);
+
+  if (cacheCollection == null) {
+    navigateTo404(navigation);
+    return null;
+  }
 
   async function fetchMembers() {
     const colMgr = etebase.getCollectionManager();
-    const col = colMgr.cacheLoad(collections.get(colUid)!.cache);
+    const col = colMgr.cacheLoad(cacheCollection!.cache);
     if (col.accessLevel !== Etebase.CollectionAccessLevel.Admin) {
       setError(`Only the owner of the collection can view and modify its members.`);
       return;

--- a/src/screens/ItemEditScreen.tsx
+++ b/src/screens/ItemEditScreen.tsx
@@ -21,6 +21,7 @@ import LoadingIndicator from "../widgets/LoadingIndicator";
 import Menu from "../widgets/Menu";
 import NoteEditDialog from "../components/NoteEditDialog";
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
+import { navigateTo404 } from "../helpers";
 
 type RootStackParamList = {
   ItemEditScreen: {
@@ -61,8 +62,20 @@ export default function ItemEditScreen(props: PropsType) {
 
   const colUid = props.route.params.colUid;
   const itemUid = props.route.params.itemUid;
+  const cacheCollection = cacheItems.get(colUid);
+  const hasItem = cacheCollection?.has(itemUid);
+
+  if (cacheCollection == null || !hasItem) {
+    navigateTo404(
+      navigation,
+      (cacheCollection != null) ? "Note not found" : undefined,
+      (cacheCollection != null) ? "This note can't be found" : undefined
+    );
+    return null;
+  }
+
   const changed = syncItems.hasIn([colUid, itemUid]);
-  const cacheItem = cacheItems.get(colUid)!.get(itemUid)!;
+  const cacheItem = cacheCollection.get(itemUid)!;
 
   function setChanged(value: boolean) {
     if (changed === value) {

--- a/src/screens/NotFoundScreen.tsx
+++ b/src/screens/NotFoundScreen.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { View, StyleSheet } from "react-native";
+import { Subheading, Title, useTheme } from "react-native-paper";
+import { RouteProp, useNavigation } from "@react-navigation/native";
+
+type NotFoundParamList = {
+  "404": {
+    title?: string;
+    message?: string;
+    help?: string;
+  };
+};
+
+interface PropsType {
+  route: RouteProp<NotFoundParamList, "404">;
+}
+
+export default function NotFound(props: PropsType) {
+  const { title, message, help } = props.route.params ?? {};
+  const navigation = useNavigation();
+  const theme = useTheme();
+
+  React.useEffect(() => {
+    navigation.setOptions({
+      title: title ?? "Page Not Found",
+    });
+  }, [navigation, title]);
+
+  return (
+    <View style={[{ backgroundColor: theme.colors.background }, styles.container]}>
+      <Title>{message ?? "Sorry, we couldn't find this page"}</Title>
+      <Subheading>{help ?? "Go back or contact us if the problem persists"}</Subheading>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 8,
+  },
+});

--- a/src/screens/NoteListScreen.tsx
+++ b/src/screens/NoteListScreen.tsx
@@ -16,7 +16,7 @@ import { useAsyncDispatch, StoreState } from "../store";
 import { performSync, setCacheItem, setSettings, setSyncItem } from "../store/actions";
 import { useCredentials } from "../credentials";
 import NoteEditDialog from "../components/NoteEditDialog";
-import { NoteMetadata } from "../helpers";
+import { NoteMetadata, navigateTo404 } from "../helpers";
 import Menu from "../widgets/Menu";
 
 
@@ -80,10 +80,13 @@ export default function NoteListScreen(props: PropsType) {
   const syncGate = useSyncGate();
   const theme = useTheme();
 
-  const colUid_ = props.route.params?.colUid;
-  const cacheCollection = (colUid_) ? cacheCollections.get(colUid_) : undefined;
-  // We only want to set colUid if a collection actually exists
-  const colUid = (cacheCollection) ? colUid_ : undefined;
+  const colUid = props.route.params?.colUid;
+  const cacheCollection = (colUid && colUid.length > 0) ? cacheCollections.get(colUid) : undefined;
+  
+  if (colUid && colUid.length > 0 && cacheCollection == null) {
+    navigateTo404(navigation);
+    return null;
+  }
 
   React.useEffect(() => {
 


### PR DESCRIPTION
So that the web client has nice urls like this:
- home: `/:colUid?`,
- CollectionEdit: `/:colUid/edit`,
- CollectionChangelog: `/:colUid/manage`,
- CollectionMembers: `/:colUid/members`,
- ItemEdit: `/:colUid/:itemUid`,
- all the others have their name or title in lowercase, except About and DebugLogs thaht have the `settings/` prefix too.

I defined arbitrary prefixes for deep linking because TypeScript requested it, but I didn't set it up for native apps.

I had to change a bit the `Drawer` navigation so `colUid` is set as an empty string instead of undefined otherwise it shows up it the url. So I did a little change in `NoteListScreen` that's pretty useless I guess to avoid querying the `cacheCollection` with an empty string.

This fixes #27. What's requested in the title anyway. We still need to display a pointer when we hover components that trigger navigation. If I remember correctly that was being worked on both in `react-native-paper` and `react-navigation`.

Tested on Firefox Linux and Android