### PR TITLE
Fix header at the top for web

### DIFF
--- a/src/RootNavigator.tsx
+++ b/src/RootNavigator.tsx
@@ -66,6 +66,9 @@ export default React.memo(function RootNavigator() {
           headerBackTitleStyle: {
             backgroundColor: "black",
           },
+          cardStyle: {
+            maxHeight: "100%",
+          },
         }}
       >
         {(etebase === null) ? (
@@ -101,9 +104,6 @@ export default React.memo(function RootNavigator() {
                 headerLeft: () => (
                   <MenuButton />
                 ),
-                cardStyle: {
-                  maxHeight: "100%",
-                },
               }}
             />
             <Stack.Screen


### PR DESCRIPTION
On web, most of the time the scroll is happening on the `html` element, even if we use `ScrollView`s or `FlatList`s. This fixes that by forcing every "card" (screen) in the navigator to be at most 100% of the screen height.

It shouldn't break anything since as far as I've seen all screens are either wrapped in a `ScrollView` or use a `List` or a `FlatList`.

This fixes #41.
This is part of #53.

Tested on Web Firefox Linux, Chromium Linux
Tested on Native Android