### PR TITLE
Add a font setting for editor and viewer

### DIFF
--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as React from "react";
-import { AppState, AppStateStatus } from "react-native";
+import { AppState, AppStateStatus, Platform } from "react-native";
 import * as Etebase from "etebase";
 import { NavigationProp } from "@react-navigation/native";
 
@@ -161,3 +161,23 @@ export function navigateTo404(navigation: NavigationProp<Record<string, object |
     message,
   });
 }
+
+export declare type FontFamilyKey = "regular" | "monospace" | "serif";
+ 
+export const fontFamilies = Platform.select({
+  web: {
+    regular: 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
+    monospace: 'SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace',
+    serif: '"Times New Roman", Georgia, serif',
+  },
+  ios: {
+    regular: "System",
+    monospace: "Courier",
+    serif: "Times New Roman",
+  },
+  default: {
+    regular: "sans-serif",
+    monospace: "monospace",
+    serif: "serif",
+  },
+});

--- a/src/screens/ItemEditScreen.tsx
+++ b/src/screens/ItemEditScreen.tsx
@@ -21,7 +21,7 @@ import LoadingIndicator from "../widgets/LoadingIndicator";
 import Menu from "../widgets/Menu";
 import NoteEditDialog from "../components/NoteEditDialog";
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
-import { navigateTo404 } from "../helpers";
+import { fontFamilies, navigateTo404 } from "../helpers";
 
 type RootStackParamList = {
   ItemEditScreen: {
@@ -306,6 +306,8 @@ interface TextEditorPropsType extends ViewProps {
 function TextEditor(props: TextEditorPropsType) {
   const { content, setContent } = props;
   const fontSize = useSelector((state: StoreState) => state.settings.fontSize);
+  const fontFamilyKey = useSelector((state: StoreState) => state.settings.viewSettings.editorFontFamily) ?? "monospace";
+  const fontFamily = fontFamilies[fontFamilyKey];
   const theme = useTheme();
 
   return (
@@ -318,7 +320,7 @@ function TextEditor(props: TextEditorPropsType) {
         textAlignVertical="top"
         multiline
         scrollEnabled
-        style={[{ flexGrow: 1, fontSize }, props.contentStyle]}
+        style={[{ flexGrow: 1, fontSize, fontFamily }, props.contentStyle]}
         onChangeText={setContent}
         value={content}
       />

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -24,6 +24,7 @@ import * as C from "../constants";
 import { startTask, enforcePasswordRules } from "../helpers";
 import { useNavigation } from "@react-navigation/native";
 import Alert from "../widgets/Alert";
+import FontSelector from "../widgets/FontSelector";
 import Select from "../widgets/Select";
 
 interface DialogPropsType {
@@ -222,6 +223,76 @@ function FontSizePreferenceSelector() {
   );
 }
 
+function EditorFontFamilyPreferenceSelector() {
+  const dispatch = useDispatch();
+  const [selectEditorFontFamilyOpen, setEditorFontFamilyPreferenceOpen] = React.useState(false);
+  const viewSettings = useSelector((state: StoreState) => state.settings.viewSettings);
+  const { editorFontFamily } = viewSettings;
+
+  return (
+    <List.Item
+      title="Editor Font"
+      description="Set the font used in the note editor"
+      right={(props) =>
+        <FontSelector
+          {...props}
+          visible={selectEditorFontFamilyOpen}
+          selected={editorFontFamily ?? "monospace"}
+          onOpen={() => setEditorFontFamilyPreferenceOpen(true)}
+          onDismiss={() => setEditorFontFamilyPreferenceOpen(false)}
+          onChange={(selected) => {
+            setEditorFontFamilyPreferenceOpen(false);
+            if (selected == null || selected === editorFontFamily) {
+              return;
+            }
+            dispatch(setSettings({
+              viewSettings: {
+                ...viewSettings,
+                editorFontFamily: selected,
+              },
+            }));
+          }}
+        />
+      }
+    />
+  );
+}
+
+function ViewerFontFamilyPreferenceSelector() {
+  const dispatch = useDispatch();
+  const [selectViewerFontFamilyOpen, setViewerFontFamilyPreferenceOpen] = React.useState(false);
+  const viewSettings = useSelector((state: StoreState) => state.settings.viewSettings);
+  const { viewerFontFamily } = viewSettings;
+
+  return (
+    <List.Item
+      title="Preview Font"
+      description="Set the font used in the note preview"
+      right={(props) =>
+        <FontSelector
+          {...props}
+          visible={selectViewerFontFamilyOpen}
+          selected={viewerFontFamily ?? "regular"}
+          onOpen={() => setViewerFontFamilyPreferenceOpen(true)}
+          onDismiss={() => setViewerFontFamilyPreferenceOpen(false)}
+          onChange={(selected) => {
+            setViewerFontFamilyPreferenceOpen(false);
+            if (selected == null || selected === viewerFontFamily) {
+              return;
+            }
+            dispatch(setSettings({
+              viewSettings: {
+                ...viewSettings,
+                viewerFontFamily: selected as typeof viewerFontFamily,
+              },
+            }));
+          }}
+        />
+      }
+    />
+  );
+}
+
 const SettingsScreen = function _SettingsScreen() {
   const etebase = useCredentials();
   const navigation = useNavigation();
@@ -265,6 +336,8 @@ const SettingsScreen = function _SettingsScreen() {
           <List.Subheader>General</List.Subheader>
           <DarkModePreferenceSelector />
           <FontSizePreferenceSelector />
+          <EditorFontFamilyPreferenceSelector />
+          <ViewerFontFamilyPreferenceSelector />
           <List.Item
             title="About"
             description="About and open source licenses"

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -9,6 +9,7 @@ import * as Etebase from "etebase";
 
 import * as actions from "./actions";
 import { LogLevel } from "../logging";
+import { FontFamilyKey } from "../helpers";
 
 interface BaseModel {
   uid: string;
@@ -355,6 +356,8 @@ export interface SettingsType {
     viewMode: boolean;
     filterBy: string | null;
     sortBy: "name" | "mtime";
+    editorFontFamily: FontFamilyKey;
+    viewerFontFamily: FontFamilyKey;
   };
 }
 
@@ -374,6 +377,8 @@ export const settingsReducer = handleActions(
       viewMode: false,
       filterBy: null,
       sortBy: "name",
+      editorFontFamily: "monospace",
+      viewerFontFamily: "regular",
     },
   }
 );

--- a/src/widgets/FontSelector.tsx
+++ b/src/widgets/FontSelector.tsx
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2019 EteSync Authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import * as React from "react";
+import { ViewProps } from "react-native";
+import { Button, useTheme } from "react-native-paper";
+import { fontFamilies, FontFamilyKey } from "../helpers";
+import Menu from "./Menu";
+
+interface PropsType extends ViewProps {
+  visible: boolean;
+  selected: FontFamilyKey;
+  onChange: (item: FontFamilyKey) => void;
+  onDismiss: () => void;
+  onOpen: () => void;
+}
+
+export default function FontSelector(inProps: React.PropsWithChildren<PropsType>) {
+  const { visible, selected, onDismiss, onChange, onOpen, ...props } = inProps;
+  const theme = useTheme();
+  const prettyName = {
+    regular: "Normal",
+    monospace: "Monospace",
+    serif: "Serif",
+  };
+
+  return (
+    <Menu
+      visible={visible}
+      onDismiss={onDismiss}
+      anchor={(
+        <Button mode="contained" color={theme.colors.accent} onPress={onOpen}>{selected && prettyName[selected]}</Button>
+      )}
+      {...props}
+    >
+      {Object.keys(prettyName).map((font, idx) => (
+        <Menu.Item key={idx} onPress={() => onChange(font as FontFamilyKey)} title={prettyName[font]} titleStyle={{ fontFamily: fontFamilies[font] }} />
+      ))}
+    </Menu>
+  );
+}

--- a/src/widgets/Markdown/index.tsx
+++ b/src/widgets/Markdown/index.tsx
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as React from "react";
-import { Linking, Platform, StyleSheet, View, ViewProps } from "react-native";
-import { Checkbox, useTheme } from "react-native-paper";
+import { Linking, StyleSheet, View, ViewProps } from "react-native";
+import { Checkbox, DefaultTheme, useTheme } from "react-native-paper";
 import MarkdownDisplay, { MarkdownIt, renderRules, RenderRules } from "react-native-markdown-display";
 import { useSelector } from "react-redux";
+import { fontFamilies, FontFamilyKey } from "../../helpers";
 import { StoreState } from "../../store";
 import TaskList from "./markdown-it-tasklist";
 import toggleCheckbox from "./toggle-checkbox";
 
-const getStyles = (theme: ReactNativePaper.Theme, fontSize: number) => {
+const getStyles = (theme: typeof DefaultTheme, fontSize: number, fontFamilyKey: FontFamilyKey) => {
   const defaults = {
     header: {
       fontWeight: "bold",
@@ -18,11 +19,6 @@ const getStyles = (theme: ReactNativePaper.Theme, fontSize: number) => {
       marginBottom: 10,
     },
     margin: 16,
-    monospaceFont: Platform.select({
-      ios: "Courier",
-      android: "monospace",
-      default: "SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace",
-    }),
   };
 
   const extraColors = (theme.dark) ? {
@@ -41,6 +37,7 @@ const getStyles = (theme: ReactNativePaper.Theme, fontSize: number) => {
     body: {
       color: theme.colors.text,
       fontSize,
+      fontFamily: fontFamilies[fontFamilyKey],
     },
     heading1: {
       ...defaults.header,
@@ -101,14 +98,14 @@ const getStyles = (theme: ReactNativePaper.Theme, fontSize: number) => {
       backgroundColor: extraColors.blockBackground,
       borderWidth: 0,
       color: extraColors.blockText,
-      fontFamily: defaults.monospaceFont,
+      fontFamily: fontFamilies.monospace,
       padding: 3,
     },
     code_block: {
       backgroundColor: extraColors.blockBackground,
       borderColor: extraColors.border,
       color: extraColors.blockText,
-      fontFamily: defaults.monospaceFont,
+      fontFamily: fontFamilies.monospace,
       marginBottom: defaults.margin,
       padding: defaults.margin,
     },
@@ -116,7 +113,7 @@ const getStyles = (theme: ReactNativePaper.Theme, fontSize: number) => {
       backgroundColor: extraColors.blockBackground,
       borderColor: extraColors.border,
       color: extraColors.blockText,
-      fontFamily: defaults.monospaceFont,
+      fontFamily: fontFamilies.monospace,
       marginBottom: defaults.margin,
       padding: defaults.margin,
     },
@@ -202,12 +199,13 @@ const Markdown = React.memo(function _Markdown(props: MarkdownPropsType) {
   const { content, setContent } = props;
   const theme = useTheme();
   const fontSize = useSelector((state: StoreState) => state.settings.fontSize);
+  const fontFamilyKey = useSelector((state: StoreState) => state.settings.viewSettings.viewerFontFamily) ?? "regular";
 
   return (
     <MarkdownDisplay
       markdownit={markdownItInstance}
       rules={getRules(content, setContent)}
-      style={getStyles(theme, fontSize)}
+      style={getStyles(theme, fontSize, fontFamilyKey)}
       mergeStyle
       onLinkPress={(url) => {
         Linking.openURL(url);


### PR DESCRIPTION
This adds two settings, one for each view. The defaults are `monospace` for the editor and `normal` (system font) for the viewer.

I had to go in different files so I hope I didn't make a mess, or make more of a mess:
- I didn't know where to store the font list so I put them in helpers…
- I created a `FontFamilyKey` type with strings, maybe using an enum is cleaner?
- I created a `FontSelector` based on the `Select` to be able to showcase the font in the menu items.

If you want me to tidy some things up while I'm at it, don't hesitate.

Tested web on Firefox Linux
Tested native Android