### PR TITLE
Add setting for default view mode

### DIFF
--- a/src/screens/ItemEditScreen.tsx
+++ b/src/screens/ItemEditScreen.tsx
@@ -39,7 +39,8 @@ export default function ItemEditScreen(props: PropsType) {
   const [loading, setLoading] = React.useState(true);
   const [content, setContent_] = React.useState("");
   const viewSettings = useSelector((state: StoreState) => state.settings.viewSettings);
-  const { viewMode } = viewSettings;
+  const { defaultViewMode, lastViewMode } = viewSettings;
+  const [viewMode, setViewMode] = React.useState((defaultViewMode === "last") ? lastViewMode : (defaultViewMode === "viewer"));
   const [noteEditDialogShow, setNoteEditDialogShow] = React.useState(false);
   const [noteDeleteDialogShow, setNoteDeleteDialogShow] = React.useState(false);
   const dispatch = useAsyncDispatch();
@@ -51,11 +52,12 @@ export default function ItemEditScreen(props: PropsType) {
   const navigation = useNavigation();
   const syncGate = useSyncGate();
 
-  function setViewMode(viewMode: boolean) {
+  function setLastViewMode(viewMode: boolean) {
+    setViewMode(viewMode);
     syncDispatch(setSettings({
       viewSettings: {
         ...viewSettings,
-        viewMode,
+        lastViewMode: viewMode,
       },
     }));
   }
@@ -160,7 +162,7 @@ export default function ItemEditScreen(props: PropsType) {
       headerRight: () => (
         <RightAction
           viewMode={viewMode}
-          setViewMode={setViewMode}
+          setViewMode={setLastViewMode}
           onSave={onSave}
           onEdit={() => setNoteEditDialogShow(true)}
           onDelete={() => setNoteDeleteDialogShow(true)}
@@ -168,7 +170,7 @@ export default function ItemEditScreen(props: PropsType) {
         />
       ),
     });
-  }, [navigation, colUid, cacheItem, viewMode, setViewMode, changed]);
+  }, [navigation, colUid, cacheItem, viewMode, setLastViewMode, changed]);
 
   function setContent(content: string) {
     setChanged(true);
@@ -306,7 +308,7 @@ interface TextEditorPropsType extends ViewProps {
 function TextEditor(props: TextEditorPropsType) {
   const { content, setContent } = props;
   const fontSize = useSelector((state: StoreState) => state.settings.fontSize);
-  const fontFamilyKey = useSelector((state: StoreState) => state.settings.viewSettings.editorFontFamily) ?? "monospace";
+  const fontFamilyKey = useSelector((state: StoreState) => state.settings.viewSettings.editorFontFamily);
   const fontFamily = fontFamilies[fontFamilyKey];
   const theme = useTheme();
 

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -19,6 +19,7 @@ import PasswordInput from "../widgets/PasswordInput";
 
 import { StoreState, useAsyncDispatch } from "../store";
 import { setSettings, login, pushMessage } from "../store/actions";
+import { ViewModeKey } from "../store/reducers";
 
 import * as C from "../constants";
 import { startTask, enforcePasswordRules } from "../helpers";
@@ -293,6 +294,53 @@ function ViewerFontFamilyPreferenceSelector() {
   );
 }
 
+function ViewModePreferenceSelector() {
+  const theme = useTheme();
+  const dispatch = useDispatch();
+  const [selectViewModeOpen, setViewModePreferenceOpen] = React.useState(false);
+  const viewSettings = useSelector((state: StoreState) => state.settings.viewSettings);
+  const { defaultViewMode } = viewSettings;
+
+  const options: ViewModeKey[] = ["last", "viewer", "editor"];
+
+  const prettyName: Record<ViewModeKey, string> = {
+    last: "Last used",
+    viewer: "Preview",
+    editor: "Editor",
+  };
+
+  return (
+    <List.Item
+      title="Default View Mode"
+      description="Set the default view mode for notes"
+      right={(props) =>
+        <Select
+          {...props}
+          visible={selectViewModeOpen}
+          onDismiss={() => setViewModePreferenceOpen(false)}
+          options={options}
+          titleAccossor={(x) => prettyName[x]}
+          onChange={(selected) => {
+            setViewModePreferenceOpen(false);
+            if (!selected || selected === defaultViewMode) {
+              return;
+            }
+            dispatch(setSettings({
+              viewSettings: {
+                ...viewSettings,
+                defaultViewMode: selected,
+              },
+            }));
+          }}
+          anchor={(
+            <Button mode="contained" color={theme.colors.accent} onPress={() => setViewModePreferenceOpen(true)}>{prettyName[defaultViewMode]}</Button>
+          )}
+        />
+      }
+    />
+  );
+}
+
 const SettingsScreen = function _SettingsScreen() {
   const etebase = useCredentials();
   const navigation = useNavigation();
@@ -338,6 +386,7 @@ const SettingsScreen = function _SettingsScreen() {
           <FontSizePreferenceSelector />
           <EditorFontFamilyPreferenceSelector />
           <ViewerFontFamilyPreferenceSelector />
+          <ViewModePreferenceSelector />
           <List.Item
             title="About"
             description="About and open source licenses"

--- a/src/store/construct.ts
+++ b/src/store/construct.ts
@@ -14,7 +14,7 @@ import { List, Map as ImmutableMap } from "immutable";
 
 import {
   SettingsType,
-  fetchCount, syncCount, credentials, settingsReducer, syncStatusReducer, lastSyncReducer, connectionReducer, errorsReducer, ErrorsData,
+  fetchCount, syncCount, credentials, settingsReducer, syncStatusReducer, lastSyncReducer, connectionReducer, errorsReducer,
   CredentialsData, SyncCollectionsData, SyncGeneralData,
   collections, items, syncCollections, syncItems, syncGeneral, CachedCollectionsData, CachedItemsData, SyncItemsData, messagesReducer, Message,
 } from "./reducers";
@@ -37,14 +37,33 @@ export interface StoreState {
     items: CachedItemsData;
   };
   connection: NetInfoStateType | null;
-  errors: ErrorsData;
+  errors: List<Error>;
   messages: List<Message>;
 }
 
+const settingsMigrations = {
+  1: (state: any) => {
+    const oldViewSettings = { ...state.viewSettings };
+    const viewSettings = {
+      defaultViewMode: "last",
+      lastViewMode: oldViewSettings.viewMode ?? false,
+      filterBy: oldViewSettings.filterBy,
+      sortBy: oldViewSettings.sortBy,
+      editorFontFamily: oldViewSettings.editorFontFamily ?? "monospace",
+      viewerFontFamily: oldViewSettings.viewerFontFamily ?? "regular",
+    };
+    return {
+      ...state,
+      viewSettings,
+    };
+  },
+};
+
 const settingsPersistConfig = {
   key: "settings",
-  version: 0,
+  version: 1,
   storage: AsyncStorage,
+  migrate: createMigrate(settingsMigrations, { debug: false }),
 };
 
 const credentialsPersistConfig = {

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -321,6 +321,8 @@ export const messagesReducer = handleActions(
 );
 
 // FIXME Move all the below (potentially the fetchCount ones too) to their own file
+export type ViewModeKey = "last" | "viewer" | "editor";
+
 export interface SettingsType {
   locale: string;
   logLevel: LogLevel;
@@ -328,7 +330,8 @@ export interface SettingsType {
   theme: "auto" | "dark" | "light";
   fontSize: number;
   viewSettings: {
-    viewMode: boolean;
+    defaultViewMode: ViewModeKey;
+    lastViewMode: boolean;
     filterBy: string | null;
     sortBy: "name" | "mtime";
     editorFontFamily: FontFamilyKey;
@@ -349,7 +352,8 @@ export const settingsReducer = handleActions(
     theme: "auto",
     fontSize: 16,
     viewSettings: {
-      viewMode: false,
+      defaultViewMode: "last",
+      lastViewMode: false,
       filterBy: null,
       sortBy: "name",
       editorFontFamily: "monospace",

--- a/src/widgets/Markdown/index.tsx
+++ b/src/widgets/Markdown/index.tsx
@@ -199,7 +199,7 @@ const Markdown = React.memo(function _Markdown(props: MarkdownPropsType) {
   const { content, setContent } = props;
   const theme = useTheme();
   const fontSize = useSelector((state: StoreState) => state.settings.fontSize);
-  const fontFamilyKey = useSelector((state: StoreState) => state.settings.viewSettings.viewerFontFamily) ?? "regular";
+  const fontFamilyKey = useSelector((state: StoreState) => state.settings.viewSettings.viewerFontFamily);
 
   return (
     <MarkdownDisplay


### PR DESCRIPTION
There are three settings: `Last used` (default, the only one until now), `Preview` and `Editor`.

This fixes #28.

Tested on web Firefox Linux
Tested on native Android