### PR TITLE
Handle better refresh token errors

### DIFF
--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -19,7 +19,7 @@ import { logger, LogLevel, getLogs } from "./logging";
 import Container from "./widgets/Container";
 import { expo } from "../app.json";
 import * as C from "./constants";
-import { setSettings, popError, login } from "./store/actions";
+import { setSettings, addError, popError, login } from "./store/actions";
 import LogoutDialog from "./components/LogoutDialog";
 import ConfirmationDialog from "./widgets/ConfirmationDialog";
 import PasswordInput from "./widgets/PasswordInput";
@@ -55,7 +55,11 @@ function SessionExpiredDialog() {
         dispatch(login(etebase));
         dispatch(popError());
       } catch (e) {
-        setFetchFailed(true);
+        if (e instanceof Etebase.UnauthorizedError) {
+          setFetchFailed(true);
+        } else {
+          dispatch(addError(e));
+        }
       }
     };
 


### PR DESCRIPTION
This fixes the concern in [this comment](https://github.com/etesync/etesync-notes/pull/80#discussion_r551153264) in #80.

Tested on web Firefox Linux
Tested on native Android