### PR TITLE
Add stack types and rename Home and NoteEditScreen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,31 @@ import "react-native-gesture-handler";
 import { enableScreens } from "react-native-screens";
 import { useSelector } from "react-redux";
 import { StoreState } from "./store";
+import { RootStackParamList } from "./RootStackParamList";
 enableScreens();
 
 const DrawerNavigation = createDrawerNavigator();
+
+type RootStackScreens = {
+  [route in keyof RootStackParamList]: string;
+};
+
+const rootStackScreens: RootStackScreens = {
+  Home: "notes/:colUid?",
+  Login: "login",
+  Signup: "signup",
+  CollectionCreate: "notes/new-notebook",
+  CollectionEdit: "notes/:colUid/edit",
+  CollectionChangelog: "notes/:colUid/manage",
+  CollectionMembers: "notes/:colUid/members",
+  NoteEdit: "notes/:colUid/:itemUid",
+  Invitations: "invitations",
+  Settings: "settings",
+  About: "settings/about",
+  DebugLogs: "settings/logs",
+  AccountWizard: "account-wizard",
+  "404": "*",
+};
 
 const linking = {
   prefixes: ["https://notes.etesync.com", "com.etesync.notes://"],
@@ -29,22 +51,7 @@ const linking = {
     screens: {
       Root: {
         path: "",
-        screens: {
-          home: "notes/:colUid?",
-          LoginScreen: "login",
-          Signup: "signup",
-          CollectionCreate: "notes/new-notebook",
-          CollectionEdit: "notes/:colUid/edit",
-          CollectionChangelog: "notes/:colUid/manage",
-          CollectionMembers: "notes/:colUid/members",
-          ItemEdit: "notes/:colUid/:itemUid",
-          Invitations: "invitations",
-          Settings: "settings",
-          About: "settings/about",
-          DebugLogs: "settings/logs",
-          AccountWizard: "account-wizard",
-          "404": "*",
-        },
+        screens: rootStackScreens,
       },
     },
   },

--- a/src/Drawer.tsx
+++ b/src/Drawer.tsx
@@ -3,10 +3,10 @@
 
 import * as React from "react";
 import { useSelector } from "react-redux";
-import { ParamListBase } from "@react-navigation/native";
 import { DrawerNavigationProp } from "@react-navigation/drawer";
 import { Image, Linking, View, StatusBar } from "react-native";
 import { Divider, List, Text, Paragraph } from "react-native-paper";
+import { IconSource } from "react-native-paper/lib/typescript/src/components/Icon";
 import SafeAreaView from "react-native-safe-area-view";
 
 import { StoreState } from "./store";
@@ -21,8 +21,15 @@ import LogoutDialog from "./components/LogoutDialog";
 
 import * as C from "./constants";
 import { useCredentials } from "./credentials";
+import { RootStackParamList } from "./RootStackParamList";
 
-const menuItems = [
+type MenuItem = {
+  title: string;
+  path: keyof RootStackParamList;
+  icon: IconSource;
+};
+
+const menuItems: MenuItem[] = [
   {
     title: "Settings",
     path: "Settings",
@@ -96,7 +103,7 @@ export default function Drawer(props: PropsType) {
   const [showFingerprint, setShowFingerprint] = React.useState(false);
   const [showLogout, setShowLogout] = React.useState(false);
   const cacheCollections = useSelector((state: StoreState) => state.cache.collections);
-  const navigation = props.navigation as DrawerNavigationProp<ParamListBase>;
+  const navigation = props.navigation as DrawerNavigationProp<RootStackParamList, keyof RootStackParamList>;
   const etebase = useCredentials();
   const loggedIn = !!etebase;
   const syncCount = useSelector((state: StoreState) => state.syncCount);
@@ -123,7 +130,7 @@ export default function Drawer(props: PropsType) {
               title="All Notes"
               onPress={() => {
                 navigation.closeDrawer();
-                navigation.navigate("home", { colUid: "" });
+                navigation.navigate("Home", { colUid: "" });
               }}
               left={(props) => <List.Icon {...props} icon="note-multiple" />}
             />
@@ -135,7 +142,7 @@ export default function Drawer(props: PropsType) {
                   title={meta.name}
                   onPress={() => {
                     navigation.closeDrawer();
-                    navigation.navigate("home", { colUid: uid });
+                    navigation.navigate("Home", { colUid: uid });
                   }}
                   left={(props) => <List.Icon {...props} icon="notebook" />}
                 />

--- a/src/RootNavigator.tsx
+++ b/src/RootNavigator.tsx
@@ -16,8 +16,8 @@ import SettingsScreen from "./screens/SettingsScreen";
 import AboutScreen from "./screens/AboutScreen";
 import DebugLogsScreen from "./screens/DebugLogsScreen";
 import NoteListScreen from "./screens/NoteListScreen";
+import NoteEditScreen from "./screens/NoteEditScreen";
 import CollectionEditScreen from "./screens/CollectionEditScreen";
-import ItemEditScreen from "./screens/ItemEditScreen";
 import CollectionChangelogScreen from "./screens/CollectionChangelogScreen";
 import CollectionMembersScreen from "./screens/CollectionMembersScreen";
 import InvitationsScreen from "./screens/InvitationsScreen";
@@ -31,8 +31,9 @@ import { useAppStateCb } from "./helpers";
 
 import * as C from "./constants";
 import { StoreState } from "./store";
+import { RootStackParamList } from "./RootStackParamList";
 
-const Stack = createStackNavigator();
+const Stack = createStackNavigator<RootStackParamList>();
 
 const MenuButton = React.memo(function MenuButton() {
   const navigation = useNavigation() as DrawerNavigationProp<any>;
@@ -75,7 +76,7 @@ export default React.memo(function RootNavigator() {
         {(etebase === null) ? (
           <>
             <Stack.Screen
-              name="LoginScreen"
+              name="Login"
               component={LoginScreen}
               options={{
                 title: "Login",
@@ -98,8 +99,9 @@ export default React.memo(function RootNavigator() {
         ) : (
           <>
             <Stack.Screen
-              name="home"
+              name="Home"
               component={NoteListScreen}
+              initialParams={{ colUid: "" }}
               options={{
                 title: C.appName,
                 headerLeft: () => (
@@ -130,8 +132,8 @@ export default React.memo(function RootNavigator() {
               }}
             />
             <Stack.Screen
-              name="ItemEdit"
-              component={ItemEditScreen}
+              name="NoteEdit"
+              component={NoteEditScreen}
             />
             <Stack.Screen
               name="Invitations"

--- a/src/RootStackParamList.tsx
+++ b/src/RootStackParamList.tsx
@@ -1,0 +1,24 @@
+
+export type RootStackParamList = {
+  Home: { colUid: string };
+  Login: undefined;
+  Signup: undefined;
+  CollectionCreate: undefined;
+  CollectionEdit: { colUid: string };
+  CollectionChangelog: { colUid: string };
+  CollectionMembers: { colUid: string };
+  NoteEdit: {
+    colUid: string;
+    itemUid: string;
+  };
+  Invitations: undefined;
+  Settings: undefined;
+  About: undefined;
+  DebugLogs: undefined;
+  AccountWizard: undefined;
+  "404": {
+    title?: string;
+    message?: string;
+    help?: string;
+  };
+};

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -4,9 +4,10 @@
 import * as React from "react";
 import { AppState, AppStateStatus, Platform } from "react-native";
 import * as Etebase from "etebase";
-import { NavigationProp } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
 
 import { logger } from "./logging";
+import { RootStackParamList } from "./RootStackParamList";
 
 export const defaultColor = "#8BC34A";
 
@@ -154,8 +155,9 @@ export function enforcePasswordRules(password: string): string | undefined {
   return undefined;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export function navigateTo404(navigation: NavigationProp<Record<string, object | undefined>>, title = "Notebook not found", message = "This notebook can't be found") {
+export type DefaultNavigationProp = StackNavigationProp<RootStackParamList, keyof RootStackParamList>;
+
+export function navigateTo404(navigation: DefaultNavigationProp, title = "Notebook not found", message = "This notebook can't be found") {
   navigation.navigate("404", {
     title,
     message,

--- a/src/screens/AccountWizardScreen.tsx
+++ b/src/screens/AccountWizardScreen.tsx
@@ -15,11 +15,13 @@ import { SyncManager } from "../sync/SyncManager";
 import { store } from "../store";
 import { useCredentials } from "../credentials";
 import { useNavigation } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
 import { useSyncGate } from "../SyncGate";
 import { useDispatch } from "react-redux";
 import { performSync } from "../store/actions";
 
 import * as C from "../constants";
+import { RootStackParamList } from "../RootStackParamList";
 
 const wizardPages = [
   (props: PagePropsType) => (
@@ -82,6 +84,8 @@ function SetupCollectionsPage(props: PagePropsType) {
   );
 }
 
+type NavigationProp = StackNavigationProp<RootStackParamList, "AccountWizard">;
+
 export default function AccountWizardScreen() {
   const [tryCount, setTryCount] = React.useState(0);
   const [ranWizard, setRanWizard] = React.useState(false);
@@ -89,7 +93,7 @@ export default function AccountWizardScreen() {
   const etebase = useCredentials();
   const dispatch = useDispatch();
   const syncGate = useSyncGate();
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp>();
   const [loading, setLoading] = React.useState(true);
 
   React.useEffect(() => {
@@ -120,13 +124,13 @@ export default function AccountWizardScreen() {
 
   React.useEffect(() => {
     if (etebase === null) {
-      navigation.navigate("LoginScreen");
+      navigation.navigate("Login");
     }
   }, [etebase]);
 
   React.useEffect(() => {
     if (!syncError && !syncGate && ranWizard) {
-      navigation.navigate("home", undefined);
+      navigation.navigate("Home", { colUid: "" });
     }
   }, [ranWizard, syncError, syncGate]);
 

--- a/src/screens/CollectionChangelogScreen.tsx
+++ b/src/screens/CollectionChangelogScreen.tsx
@@ -7,6 +7,7 @@ import { useSelector } from "react-redux";
 import { FlatList, View } from "react-native";
 import { Divider, Appbar, Text, List, useTheme } from "react-native-paper";
 import { useNavigation, RouteProp } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
 
 import { useSyncGate } from "../SyncGate";
 import { StoreState } from "../store";
@@ -15,25 +16,22 @@ import Container from "../widgets/Container";
 import Menu from "../widgets/Menu";
 import { Title } from "../widgets/Typography";
 
-import { defaultColor, navigateTo404 } from "../helpers";
+import { defaultColor, DefaultNavigationProp, navigateTo404 } from "../helpers";
+import { RootStackParamList } from "../RootStackParamList";
 
 import ColorBox from "../widgets/ColorBox";
 
 const iconDeleted = (props: any) => (<List.Icon {...props} color="#F20C0C" icon="delete" />);
 const iconChanged = (props: any) => (<List.Icon {...props} color="#FEB115" icon="pencil" />);
 
-type RootStackParamList = {
-  CollectionChangelogScreen: {
-    colUid?: string;
-  };
-};
+type NavigationProp = StackNavigationProp<RootStackParamList, "CollectionChangelog">;
 
 interface PropsType {
-  route: RouteProp<RootStackParamList, "CollectionChangelogScreen">;
+  route: RouteProp<RootStackParamList, "CollectionChangelog">;
 }
 
 export default function CollectionChangelogScreen(props: PropsType) {
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp>();
   const syncGate = useSyncGate();
   const theme = useTheme();
   const cachedCollections = useSelector((state: StoreState) => state.cache.collections);
@@ -116,7 +114,7 @@ export default function CollectionChangelogScreen(props: PropsType) {
 
 function RightAction(props: { colUid: string }) {
   const [showMenu, setShowMenu] = React.useState(false);
-  const navigation = useNavigation();
+  const navigation = useNavigation<DefaultNavigationProp>();
   const colUid = props.colUid;
 
   return (

--- a/src/screens/CollectionEditScreen.tsx
+++ b/src/screens/CollectionEditScreen.tsx
@@ -6,6 +6,7 @@ import { useSelector } from "react-redux";
 import { TextInput as NativeTextInput } from "react-native";
 import { Text, HelperText, Button, Appbar, Paragraph } from "react-native-paper";
 import { useNavigation, RouteProp } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
 
 import { SyncManager } from "../sync/SyncManager";
 import { useSyncGate } from "../SyncGate";
@@ -19,7 +20,8 @@ import Container from "../widgets/Container";
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import ErrorOrLoadingDialog from "../widgets/ErrorOrLoadingDialog";
 
-import { useLoading, defaultColor, navigateTo404 } from "../helpers";
+import { useLoading, defaultColor, navigateTo404, DefaultNavigationProp } from "../helpers";
+import { RootStackParamList } from "../RootStackParamList";
 
 import ColorPicker from "../widgets/ColorPicker";
 import * as C from "../constants";
@@ -29,14 +31,10 @@ interface FormErrors {
   color?: string;
 }
 
-type RootStackParamList = {
-  CollectionEditScreen: {
-    colUid?: string;
-  };
-};
+type NavigationProp = StackNavigationProp<RootStackParamList, "CollectionEdit"> | StackNavigationProp<RootStackParamList, "CollectionCreate">;
 
 interface PropsType {
-  route: RouteProp<RootStackParamList, "CollectionEditScreen">;
+  route: RouteProp<RootStackParamList, "CollectionEdit"> | RouteProp<RootStackParamList, "CollectionCreate">;
 }
 
 export default function CollectionEditScreen(props: PropsType) {
@@ -47,7 +45,7 @@ export default function CollectionEditScreen(props: PropsType) {
   const dispatch = useAsyncDispatch();
   const cacheCollections = useSelector((state: StoreState) => state.cache.collections);
   const syncGate = useSyncGate();
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp>();
   const etebase = useCredentials()!;
   const [loading, error, setPromise] = useLoading();
   const colType = C.colType;
@@ -192,7 +190,7 @@ export default function CollectionEditScreen(props: PropsType) {
 
 function RightAction(props: { colUid: string }) {
   const [confirmationVisible, setConfirmationVisible] = React.useState(false);
-  const navigation = useNavigation();
+  const navigation = useNavigation<DefaultNavigationProp>();
   const etebase = useCredentials()!;
   const dispatch = useAsyncDispatch();
   const cacheCollections = useSelector((state: StoreState) => state.cache.collections);
@@ -224,7 +222,7 @@ function RightAction(props: { colUid: string }) {
           collection.delete();
           await dispatch(collectionUpload(colMgr, collection));
           dispatch(pushMessage({ message: "Collection deleted", severity: "success" }));
-          navigation.navigate("home", {});
+          navigation.navigate("Home", { colUid: "" });
           // FIXME having the sync manager here is ugly. We should just deal with these changes centrally.
           const syncManager = SyncManager.getManager(etebase);
           dispatch(performSync(syncManager.sync())); // not awaiting on puprose

--- a/src/screens/CollectionMembersScreen.tsx
+++ b/src/screens/CollectionMembersScreen.tsx
@@ -7,6 +7,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { View } from "react-native";
 import { Avatar, List, Appbar, Paragraph, useTheme } from "react-native-paper";
 import { useNavigation, RouteProp } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
 
 import { useSyncGate } from "../SyncGate";
 import { useCredentials } from "../credentials";
@@ -20,15 +21,12 @@ import ErrorDialog from "../widgets/ErrorDialog";
 import CollectionMemberAddDialog from "../components/CollectionMemberAddDialog";
 import { pushMessage } from "../store/actions";
 import { navigateTo404 } from "../helpers";
+import { RootStackParamList } from "../RootStackParamList";
 
-type RootStackParamList = {
-  CollectionMembersScreen: {
-    colUid: string;
-  };
-};
+type NavigationProp = StackNavigationProp<RootStackParamList, "CollectionMembers">;
 
 interface PropsType {
-  route: RouteProp<RootStackParamList, "CollectionMembersScreen">;
+  route: RouteProp<RootStackParamList, "CollectionMembers">;
 }
 
 
@@ -40,7 +38,7 @@ export default function CollectionMembersScreen(props: PropsType) {
   const [error, setError] = React.useState<string>();
   const collections = useSelector((state: StoreState) => state.cache.collections);
   const syncGate = useSyncGate();
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp>();
   const dispatch = useDispatch();
   const theme = useTheme();
   const etebase = useCredentials()!;

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -23,12 +23,15 @@ import * as C from "../constants";
 import { useCredentials } from "../credentials";
 import LinkButton from "../widgets/LinkButton";
 import { useNavigation } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { RootStackParamList } from "../RootStackParamList";
 
+type NavigationProp = StackNavigationProp<RootStackParamList, "Login">;
 
 const LoginScreen = React.memo(function _LoginScreen() {
   const etebase = useCredentials();
   const dispatch = useAsyncDispatch();
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp>();
   const [loading, error, setPromise] = useLoading();
 
   function onFormSubmit(username: string, password: string, serviceApiUrl?: string) {

--- a/src/screens/NotFoundScreen.tsx
+++ b/src/screens/NotFoundScreen.tsx
@@ -2,22 +2,18 @@ import * as React from "react";
 import { View, StyleSheet } from "react-native";
 import { Subheading, Title, useTheme } from "react-native-paper";
 import { RouteProp, useNavigation } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { RootStackParamList } from "../RootStackParamList";
 
-type NotFoundParamList = {
-  "404": {
-    title?: string;
-    message?: string;
-    help?: string;
-  };
-};
+type NavigationProp = StackNavigationProp<RootStackParamList, "404">;
 
 interface PropsType {
-  route: RouteProp<NotFoundParamList, "404">;
+  route: RouteProp<RootStackParamList, "404">;
 }
 
 export default function NotFound(props: PropsType) {
   const { title, message, help } = props.route.params ?? {};
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp>();
   const theme = useTheme();
 
   React.useEffect(() => {

--- a/src/screens/NoteEditScreen.tsx
+++ b/src/screens/NoteEditScreen.tsx
@@ -6,6 +6,7 @@ import * as Etebase from "etebase";
 import { View, ViewProps, KeyboardAvoidingView, Platform } from "react-native";
 import { Appbar, Paragraph, useTheme } from "react-native-paper";
 import { useNavigation, RouteProp } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
 import { useDebouncedCallback } from "use-debounce";
 
 import { useSyncGate } from "../SyncGate";
@@ -22,19 +23,15 @@ import Menu from "../widgets/Menu";
 import NoteEditDialog from "../components/NoteEditDialog";
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import { fontFamilies, navigateTo404 } from "../helpers";
+import { RootStackParamList } from "../RootStackParamList";
 
-type RootStackParamList = {
-  ItemEditScreen: {
-    colUid: string;
-    itemUid: string;
-  };
-};
+type NavigationProp = StackNavigationProp<RootStackParamList, "NoteEdit">;
 
 interface PropsType {
-  route: RouteProp<RootStackParamList, "ItemEditScreen">;
+  route: RouteProp<RootStackParamList, "NoteEdit">;
 }
 
-export default function ItemEditScreen(props: PropsType) {
+export default function NoteEditScreen(props: PropsType) {
   const onSaveDoRef = React.useRef<() => void>();
   const [loading, setLoading] = React.useState(true);
   const [content, setContent_] = React.useState("");
@@ -49,7 +46,7 @@ export default function ItemEditScreen(props: PropsType) {
   const cacheCollections = useSelector((state: StoreState) => state.cache.collections);
   const cacheItems = useSelector((state: StoreState) => state.cache.items);
   const etebase = useCredentials()!;
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp>();
   const syncGate = useSyncGate();
 
   function setLastViewMode(viewMode: boolean) {

--- a/src/screens/NoteListScreen.tsx
+++ b/src/screens/NoteListScreen.tsx
@@ -6,6 +6,7 @@ import moment from "moment";
 import { StyleSheet, FlatList, View, Platform } from "react-native";
 import { Appbar, List, useTheme, FAB } from "react-native-paper";
 import { useNavigation, useFocusEffect, RouteProp } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
 import { useSelector, useDispatch } from "react-redux";
 
 import { useSyncGate } from "../SyncGate";
@@ -16,8 +17,9 @@ import { useAsyncDispatch, StoreState } from "../store";
 import { performSync, setCacheItem, setSettings, setSyncItem } from "../store/actions";
 import { useCredentials } from "../credentials";
 import NoteEditDialog from "../components/NoteEditDialog";
-import { NoteMetadata, navigateTo404 } from "../helpers";
+import { NoteMetadata, navigateTo404, DefaultNavigationProp } from "../helpers";
 import Menu from "../widgets/Menu";
+import { RootStackParamList } from "../RootStackParamList";
 
 
 function sortMtime(aIn: CachedItem, bIn: CachedItem) {
@@ -58,14 +60,10 @@ function getSortFunction(sortOrder: string) {
   };
 }
 
-type RootStackParamList = {
-  NoteListScreen: {
-    colUid?: string;
-  };
-};
+type NavigationProp = StackNavigationProp<RootStackParamList, "Home">;
 
 interface PropsType {
-  route: RouteProp<RootStackParamList, "NoteListScreen">;
+  route: RouteProp<RootStackParamList, "Home">;
 }
 
 export default function NoteListScreen(props: PropsType) {
@@ -76,7 +74,7 @@ export default function NoteListScreen(props: PropsType) {
   const { sortBy } = viewSettings;
   const cacheCollections = useSelector((state: StoreState) => state.cache.collections);
   const cacheItems = useSelector((state: StoreState) => state.cache.items);
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp>();
   const syncGate = useSyncGate();
   const theme = useTheme();
 
@@ -132,7 +130,7 @@ export default function NoteListScreen(props: PropsType) {
         key={item.uid}
         title={name}
         description={mtime?.format("llll")}
-        onPress={() => { navigation.navigate("ItemEdit", { colUid: item.colUid, itemUid: item.uid }) }}
+        onPress={() => { navigation.navigate("NoteEdit", { colUid: item.colUid, itemUid: item.uid }) }}
       />
     );
   }
@@ -166,7 +164,7 @@ export default function NoteListScreen(props: PropsType) {
           const item = await itemMgr.create(meta, "");
           await dispatch(setCacheItem(col, itemMgr, item));
           dispatch(setSyncItem(colUid, item.uid));
-          navigation.navigate("ItemEdit", { colUid, itemUid: item.uid });
+          navigation.navigate("NoteEdit", { colUid, itemUid: item.uid });
           setNewItemDialogShow(false);
         }}
         initialColUid={colUid}
@@ -205,7 +203,7 @@ function RightAction(props: RightActionPropsType) {
   const isSyncing = useSelector((state: StoreState) => state.syncCount) > 0;
   const selecetdStyle = { color: "green" };
   const viewSettings = useSelector((state: StoreState) => state.settings.viewSettings);
-  const navigation = useNavigation();
+  const navigation = useNavigation<DefaultNavigationProp>();
   const { colUid } = props;
 
   function setShowSortMenu(value: boolean) {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -24,9 +24,11 @@ import { ViewModeKey } from "../store/reducers";
 import * as C from "../constants";
 import { startTask, enforcePasswordRules } from "../helpers";
 import { useNavigation } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
 import Alert from "../widgets/Alert";
 import FontSelector from "../widgets/FontSelector";
 import Select from "../widgets/Select";
+import { RootStackParamList } from "../RootStackParamList";
 
 interface DialogPropsType {
   visible: boolean;
@@ -341,9 +343,11 @@ function ViewModePreferenceSelector() {
   );
 }
 
+type NavigationProp = StackNavigationProp<RootStackParamList, "Settings">;
+
 const SettingsScreen = function _SettingsScreen() {
   const etebase = useCredentials();
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp>();
   const dispatch = useDispatch();
   const theme = useTheme();
   const settings = useSelector((state: StoreState) => state.settings);

--- a/src/screens/SignupScreen.tsx
+++ b/src/screens/SignupScreen.tsx
@@ -25,6 +25,8 @@ import * as C from "../constants";
 import { useCredentials } from "../credentials";
 import LinkButton from "../widgets/LinkButton";
 import { useNavigation } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { RootStackParamList } from "../RootStackParamList";
 
 interface FormErrors {
   username?: string;
@@ -35,13 +37,15 @@ interface FormErrors {
   general?: string;
 }
 
+type NavigationProp = StackNavigationProp<RootStackParamList, "Signup">;
+
 // Can be used to force always showing advance, e.g. for genericMode
 const alwaysShowAdvanced = false;
 
 export default React.memo(function SignupScreen() {
   const etebase = useCredentials();
   const dispatch = useAsyncDispatch();
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp>();
   const [username, setUsername] = React.useState("");
   const [email, setEmail] = React.useState("");
   const [password, setPassword] = React.useState("");
@@ -130,7 +134,7 @@ export default React.memo(function SignupScreen() {
       <Container>
         <Headline>Signup</Headline>
         <View style={{ alignItems: "center", flexDirection: "row" }}>
-          <Text> or </Text><LinkButton onPress={() => navigation.navigate("LoginScreen")}>log in to your account</LinkButton>
+          <Text> or </Text><LinkButton onPress={() => navigation.navigate("Login")}>log in to your account</LinkButton>
         </View>
 
         <Alert


### PR DESCRIPTION
That allows us to have types support for the `navigation` prop, especially for `navigation.navigate()`.

Also adds [stack actions](https://reactnavigation.org/docs/stack-actions/) helpers to `navigation` like `pop()` and `replace()`.