### PR TITLE
Open notebooks select on submit note name

### DIFF
--- a/src/screens/NotePropertiesScreen.tsx
+++ b/src/screens/NotePropertiesScreen.tsx
@@ -158,6 +158,7 @@ export default function NotePropertiesScreen(props: PropsType) {
         <TextInput
           autoFocus
           returnKeyType="next"
+          onSubmitEditing={() => setSelectOpen(true)}
           error={!!errors.name}
           onChangeText={setName}
           label="Name"


### PR DESCRIPTION
This was the last step so it fixes #53.

Note: on web, even though the select opens, it is not focused so we can't chose an entry with the keyboard. This is because `Menu.Item`s are rendered as `div`s that are not deemed focusable.