### PR TITLE
TextInput used as anchor should not be editable

### DIFF
--- a/src/screens/NotePropertiesScreen.tsx
+++ b/src/screens/NotePropertiesScreen.tsx
@@ -190,7 +190,7 @@ export default function NotePropertiesScreen(props: PropsType) {
                 disabled={!!itemUid}
               >
                 <TextInputWithIcon
-                  editable
+                  editable={false}
                   label="Notebook"
                   accessibilityLabel="Notebook"
                   value={collection?.meta.name ?? "No Notebooks"}


### PR DESCRIPTION
Otherwise the text is selected when we tap the input to open the select, which is weird.