### PR TITLE
Fix error when opening right action menu on Home

### DIFF
--- a/src/screens/NoteListScreen.tsx
+++ b/src/screens/NoteListScreen.tsx
@@ -74,7 +74,7 @@ export default function NoteListScreen(props: PropsType) {
   const syncGate = useSyncGate();
   const theme = useTheme();
 
-  const colUid = props.route.params?.colUid;
+  const colUid = props.route.params?.colUid || undefined;
   const cacheCollection = (colUid && colUid.length > 0) ? cacheCollections.get(colUid) : undefined;
 
   if (colUid && colUid.length > 0 && cacheCollection == null) {


### PR DESCRIPTION
The app crashes on Android when we try to open the header's right action menu on the "All Notes" screen. This doesn't happen on web.

I'm guessing this was introduced in 8489a09b34d4b6600127f6fb1dcad03fc1040b39, because now `colUid` can also be an empty string.

This fixes it.