### PR TITLE
Replace navigateTo404 with NotFound view

### DIFF
--- a/src/RootStackParamList.tsx
+++ b/src/RootStackParamList.tsx
@@ -1,4 +1,6 @@
 
+import { StackNavigationProp } from "@react-navigation/stack";
+
 export type RootStackParamList = {
   Home: { colUid: string };
   Login: undefined;
@@ -24,9 +26,7 @@ export type RootStackParamList = {
   About: undefined;
   DebugLogs: undefined;
   AccountWizard: undefined;
-  "404": {
-    title?: string;
-    message?: string;
-    help?: string;
-  };
+  "404": undefined;
 };
+
+export type DefaultNavigationProp = StackNavigationProp<RootStackParamList, keyof RootStackParamList>;

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -4,10 +4,8 @@
 import * as React from "react";
 import { AppState, AppStateStatus, Platform } from "react-native";
 import * as Etebase from "etebase";
-import { StackNavigationProp } from "@react-navigation/stack";
 
 import { logger } from "./logging";
-import { RootStackParamList } from "./RootStackParamList";
 
 export const defaultColor = "#8BC34A";
 
@@ -153,15 +151,6 @@ export function enforcePasswordRules(password: string): string | undefined {
     return `Passwourds should be at least ${PASSWORD_MIN_LENGTH} digits long.`;
   }
   return undefined;
-}
-
-export type DefaultNavigationProp = StackNavigationProp<RootStackParamList, keyof RootStackParamList>;
-
-export function navigateTo404(navigation: DefaultNavigationProp, title = "Notebook not found", message = "This notebook can't be found") {
-  navigation.navigate("404", {
-    title,
-    message,
-  });
 }
 
 export declare type FontFamilyKey = "regular" | "monospace" | "serif";

--- a/src/screens/CollectionChangelogScreen.tsx
+++ b/src/screens/CollectionChangelogScreen.tsx
@@ -15,9 +15,10 @@ import { CachedItem } from "../store/reducers";
 import Container from "../widgets/Container";
 import Menu from "../widgets/Menu";
 import { Title } from "../widgets/Typography";
+import NotFound from "../widgets/NotFound";
 
-import { defaultColor, DefaultNavigationProp, navigateTo404 } from "../helpers";
-import { RootStackParamList } from "../RootStackParamList";
+import { defaultColor } from "../helpers";
+import { DefaultNavigationProp, RootStackParamList } from "../RootStackParamList";
 
 import ColorBox from "../widgets/ColorBox";
 
@@ -54,8 +55,7 @@ export default function CollectionChangelogScreen(props: PropsType) {
   }
 
   if (!cachedCollection || !colCachedItems) {
-    navigateTo404(navigation);
-    return null;
+    return <NotFound />;
   }
 
   const { meta } = cachedCollection;

--- a/src/screens/CollectionEditScreen.tsx
+++ b/src/screens/CollectionEditScreen.tsx
@@ -19,9 +19,10 @@ import ScrollView from "../widgets/ScrollView";
 import Container from "../widgets/Container";
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import ErrorOrLoadingDialog from "../widgets/ErrorOrLoadingDialog";
+import NotFound from "../widgets/NotFound";
 
-import { useLoading, defaultColor, navigateTo404, DefaultNavigationProp } from "../helpers";
-import { RootStackParamList } from "../RootStackParamList";
+import { useLoading, defaultColor } from "../helpers";
+import { DefaultNavigationProp, RootStackParamList } from "../RootStackParamList";
 
 import ColorPicker from "../widgets/ColorPicker";
 import * as C from "../constants";
@@ -66,8 +67,6 @@ export default function CollectionEditScreen(props: PropsType) {
         if (meta.color !== undefined) {
           setColor(meta.color);
         }
-      } else {
-        navigateTo404(navigation);
       }
     }
 
@@ -84,6 +83,10 @@ export default function CollectionEditScreen(props: PropsType) {
 
   if (syncGate) {
     return syncGate;
+  }
+
+  if (colUid && !cacheCollections.has(colUid)) {
+    return <NotFound />;
   }
 
   function onSave() {

--- a/src/screens/CollectionMembersScreen.tsx
+++ b/src/screens/CollectionMembersScreen.tsx
@@ -12,15 +12,15 @@ import { StackNavigationProp } from "@react-navigation/stack";
 import { useSyncGate } from "../SyncGate";
 import { useCredentials } from "../credentials";
 import { StoreState } from "../store";
+import { pushMessage } from "../store/actions";
 
 import ScrollView from "../widgets/ScrollView";
 import Container from "../widgets/Container";
 import LoadingIndicator from "../widgets/LoadingIndicator";
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import ErrorDialog from "../widgets/ErrorDialog";
+import NotFound from "../widgets/NotFound";
 import CollectionMemberAddDialog from "../components/CollectionMemberAddDialog";
-import { pushMessage } from "../store/actions";
-import { navigateTo404 } from "../helpers";
 import { RootStackParamList } from "../RootStackParamList";
 
 type NavigationProp = StackNavigationProp<RootStackParamList, "CollectionMembers">;
@@ -47,11 +47,6 @@ export default function CollectionMembersScreen(props: PropsType) {
 
   const colUid = props.route.params?.colUid ?? "";
   const cacheCollection = collections.get(colUid);
-
-  if (cacheCollection == null) {
-    navigateTo404(navigation);
-    return null;
-  }
 
   async function fetchMembers() {
     const colMgr = etebase.getCollectionManager();
@@ -108,6 +103,12 @@ export default function CollectionMembersScreen(props: PropsType) {
 
   if (syncGate) {
     return syncGate;
+  }
+
+  if (!cacheCollection) {
+    return (
+      <NotFound />
+    );
   }
 
   if (error) {

--- a/src/screens/NotFoundScreen.tsx
+++ b/src/screens/NotFoundScreen.tsx
@@ -1,40 +1,23 @@
 import * as React from "react";
-import { View, StyleSheet } from "react-native";
-import { Subheading, Title, useTheme } from "react-native-paper";
-import { RouteProp, useNavigation } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { RootStackParamList } from "../RootStackParamList";
+import NotFound from "../widgets/NotFound";
 
 type NavigationProp = StackNavigationProp<RootStackParamList, "404">;
 
-interface PropsType {
-  route: RouteProp<RootStackParamList, "404">;
-}
-
-export default function NotFound(props: PropsType) {
-  const { title, message, help } = props.route.params ?? {};
+export default function NotFoundScreen() {
   const navigation = useNavigation<NavigationProp>();
-  const theme = useTheme();
 
   React.useEffect(() => {
     navigation.setOptions({
-      title: title ?? "Page Not Found",
+      title: "Page Not Found",
     });
-  }, [navigation, title]);
+  }, [navigation]);
 
   return (
-    <View style={[{ backgroundColor: theme.colors.background }, styles.container]}>
-      <Title>{message ?? "Sorry, we couldn't find this page"}</Title>
-      <Subheading>{help ?? "Go back or contact us if the problem persists"}</Subheading>
-    </View>
+    <NotFound
+      message="Sorry, we couldn't find this page"
+    />
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 8,
-  },
-});

--- a/src/screens/NoteEditScreen.tsx
+++ b/src/screens/NoteEditScreen.tsx
@@ -21,7 +21,8 @@ import { setCacheItem, itemBatch, setSettings, setSyncItem, unsetSyncItem } from
 import LoadingIndicator from "../widgets/LoadingIndicator";
 import Menu from "../widgets/Menu";
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
-import { fontFamilies, navigateTo404 } from "../helpers";
+import NotFound from "../widgets/NotFound";
+import { fontFamilies } from "../helpers";
 import { RootStackParamList } from "../RootStackParamList";
 
 type NavigationProp = StackNavigationProp<RootStackParamList, "NoteEdit">;
@@ -60,19 +61,16 @@ export default function NoteEditScreen(props: PropsType) {
   const colUid = props.route.params.colUid;
   const itemUid = props.route.params.itemUid;
   const cacheCollection = cacheItems.get(colUid);
-  const hasItem = cacheCollection?.has(itemUid);
+  const cacheItem = cacheCollection?.get(itemUid);
 
-  if (cacheCollection == null || !hasItem) {
-    navigateTo404(
-      navigation,
-      (cacheCollection != null) ? "Note not found" : undefined,
-      (cacheCollection != null) ? "This note can't be found" : undefined
-    );
-    return null;
+  if (!cacheCollection) {
+    return <NotFound />;
+  }
+  if (!cacheItem) {
+    return <NotFound message="This note can't be found" />;
   }
 
   const changed = syncItems.hasIn([colUid, itemUid]);
-  const cacheItem = cacheCollection.get(itemUid)!;
 
   function setChanged(value: boolean) {
     if (changed === value) {
@@ -133,7 +131,7 @@ export default function NoteEditScreen(props: PropsType) {
     const colMgr = etebase.getCollectionManager();
     const col = colMgr.cacheLoad(cacheCollections.get(colUid)!.cache);
     const itemMgr = colMgr.getItemManager(col);
-    const item = itemMgr.cacheLoad(cacheItem.cache);
+    const item = itemMgr.cacheLoad(cacheItem!.cache);
     await item.setContent(content);
     await dispatch(itemBatch(col, itemMgr, [item]));
     setChanged(false);

--- a/src/screens/NoteListScreen.tsx
+++ b/src/screens/NoteListScreen.tsx
@@ -10,15 +10,14 @@ import { StackNavigationProp } from "@react-navigation/stack";
 import { useSelector, useDispatch } from "react-redux";
 
 import { useSyncGate } from "../SyncGate";
-import { CachedItem } from "../store";
-
+import { CachedItem, StoreState } from "../store";
 import { SyncManager } from "../sync/SyncManager";
-import { StoreState } from "../store";
 import { performSync, setSettings } from "../store/actions";
 import { useCredentials } from "../credentials";
-import { navigateTo404, DefaultNavigationProp } from "../helpers";
+
 import Menu from "../widgets/Menu";
-import { RootStackParamList } from "../RootStackParamList";
+import NotFound from "../widgets/NotFound";
+import { DefaultNavigationProp, RootStackParamList } from "../RootStackParamList";
 
 
 function sortMtime(aIn: CachedItem, bIn: CachedItem) {
@@ -75,12 +74,7 @@ export default function NoteListScreen(props: PropsType) {
   const theme = useTheme();
 
   const colUid = props.route.params?.colUid || undefined;
-  const cacheCollection = (colUid && colUid.length > 0) ? cacheCollections.get(colUid) : undefined;
-
-  if (colUid && colUid.length > 0 && cacheCollection == null) {
-    navigateTo404(navigation);
-    return null;
-  }
+  const cacheCollection = (colUid) ? cacheCollections.get(colUid) : undefined;
 
   React.useEffect(() => {
 
@@ -115,6 +109,11 @@ export default function NoteListScreen(props: PropsType) {
   if (syncGate) {
     return syncGate;
   }
+
+  if (colUid && !cacheCollection) {
+    return <NotFound />;
+  }
+
   function renderEntry(param: { item: CachedItem & { colUid: string, uid: string } }) {
     const item = param.item;
     const name = item.meta.name!;
@@ -150,7 +149,7 @@ export default function NoteListScreen(props: PropsType) {
         accessibilityLabel="New"
         color="white"
         style={styles.fab}
-        onPress={() => navigation.navigate("NoteCreate", { colUid })}
+        onPress={() => navigation.navigate("NoteCreate", colUid ? { colUid } : undefined)}
       />
     </>
   );

--- a/src/screens/NotePropertiesScreen.tsx
+++ b/src/screens/NotePropertiesScreen.tsx
@@ -21,8 +21,9 @@ import Container from "../widgets/Container";
 import ErrorOrLoadingDialog from "../widgets/ErrorOrLoadingDialog";
 import Select from "../widgets/Select";
 import TextInputWithIcon from "../widgets/TextInputWithIcon";
+import NotFound from "../widgets/NotFound";
 
-import { useLoading, navigateTo404, NoteMetadata } from "../helpers";
+import { useLoading, NoteMetadata } from "../helpers";
 import { RootStackParamList } from "../RootStackParamList";
 
 interface FormErrors {
@@ -75,15 +76,11 @@ export default function NotePropertiesScreen(props: PropsType) {
             setName(meta.name!);
             setCachedItem(cachedItem);
           } else {
-            navigateTo404(
-              navigation,
-              "Note not found",
-              "This note can't be found"
-            );
+            setCachedItem(undefined);
           }
         }
       } else {
-        navigateTo404(navigation);
+        setCollection(undefined);
       }
     }
 
@@ -97,6 +94,13 @@ export default function NotePropertiesScreen(props: PropsType) {
 
   if (syncGate) {
     return syncGate;
+  }
+
+  if (colUid && !collection) {
+    return <NotFound />;
+  }
+  if (itemUid && !cachedItem) {
+    return <NotFound message="This note can't be found" />;
   }
 
   function onSave() {

--- a/src/widgets/NotFound.tsx
+++ b/src/widgets/NotFound.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { View, StyleSheet } from "react-native";
+import { Subheading, Title, useTheme } from "react-native-paper";
+
+interface PropsType {
+  message?: string;
+  help?: string;
+}
+
+export default function NotFound(props: PropsType) {
+  const {
+    message = "This notebook can't be found",
+    help = "Go back or contact us if the problem persists",
+  } = props ?? {};
+  const theme = useTheme();
+
+  return (
+    <View style={[{ backgroundColor: theme.colors.background }, styles.container]}>
+      <Title>{message}</Title>
+      <Subheading>{help}</Subheading>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 8,
+  },
+});


### PR DESCRIPTION
This prevents React Navigation from redirecting to 404 when a parameter is wrong, instead it just shows the 404 message.

`NoteEditScreen`'s `NotFound` view was willingly put in the wrong place for now because too many changes are needed to put it in the proper place. It could trigger an error when deleting a note but it'll be fixed in an upcoming PR.

Tested on web Firefox Linux
Tested on native Android