### PR TITLE
Show links on hover in drawer for web

### DIFF
--- a/src/Drawer.tsx
+++ b/src/Drawer.tsx
@@ -5,8 +5,7 @@ import * as React from "react";
 import { useSelector } from "react-redux";
 import { DrawerNavigationProp } from "@react-navigation/drawer";
 import { Image, Linking, View, StatusBar } from "react-native";
-import { Divider, List, Text, Paragraph } from "react-native-paper";
-import { IconSource } from "react-native-paper/lib/typescript/components/Icon";
+import { Divider, Drawer as PaperDrawer, Text, Paragraph } from "react-native-paper";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { StoreState } from "./store";
@@ -16,6 +15,7 @@ import ConfirmationDialog from "./widgets/ConfirmationDialog";
 import PrettyFingerprint from "./widgets/PrettyFingerprint";
 import Container from "./widgets/Container";
 import { Subheading } from "./widgets/Typography";
+import DrawerItem from "./widgets/DrawerItem";
 
 import LogoutDialog from "./components/LogoutDialog";
 
@@ -26,7 +26,8 @@ import { RootStackParamList } from "./RootStackParamList";
 type MenuItem = {
   title: string;
   path: keyof RootStackParamList;
-  icon: IconSource;
+  icon: string;
+  link: string;
 };
 
 const menuItems: MenuItem[] = [
@@ -34,6 +35,7 @@ const menuItems: MenuItem[] = [
     title: "Settings",
     path: "Settings",
     icon: "settings",
+    link: "/settings",
   },
 ];
 
@@ -126,91 +128,96 @@ export default function Drawer(props: PropsType) {
         </SafeAreaView>
         {loggedIn && (
           <>
-            <List.Item
-              title="All Notes"
+            <DrawerItem
+              label="All Notes"
+              to="/"
               onPress={() => {
                 navigation.closeDrawer();
                 navigation.navigate("Home");
               }}
-              left={(props) => <List.Icon {...props} icon="note-multiple" />}
+              icon="note-multiple"
             />
             <Divider />
-            <List.Section title="Notebooks">
+            <PaperDrawer.Section title="Notebooks">
               {Array.from(cacheCollections
                 .sort((a, b) => (a.meta!.name!.toUpperCase() >= b.meta!.name!.toUpperCase()) ? 1 : -1)
                 .map(({ meta }, uid) => (
-                  <List.Item
+                  <DrawerItem
                     key={uid}
-                    title={meta.name}
+                    label={meta.name!}
+                    to={`/notebook/${uid}`}
                     onPress={() => {
                       navigation.closeDrawer();
                       navigation.navigate("Collection", { colUid: uid });
                     }}
-                    left={(props) => <List.Icon {...props} icon="notebook" />}
+                    icon="notebook"
                   />
                 ))
                 .values()
               )}
-              <List.Item
-                title="Create new notebook"
+              <DrawerItem
+                label="Create new notebook"
+                to="/new-notebook"
                 onPress={() => {
                   navigation.navigate("CollectionCreate");
                 }}
-                left={(props) => <List.Icon {...props} icon="plus" />}
+                icon="plus"
               />
-            </List.Section>
-            <Divider />
+            </PaperDrawer.Section>
           </>
         )}
         <>
           {menuItems.map((menuItem) => (
-            <List.Item
+            <DrawerItem
               key={menuItem.title}
-              title={menuItem.title}
+              label={menuItem.title}
+              to={menuItem.link}
               onPress={() => {
                 navigation.closeDrawer();
                 navigation.navigate(menuItem.path);
               }}
-              left={(props) => <List.Icon {...props} icon={menuItem.icon} />}
+              icon={menuItem.icon}
             />
           ))}
           {loggedIn && (
             <>
-              <List.Item
-                title="Show Fingerprint"
+              <DrawerItem
+                label="Show Fingerprint"
                 onPress={() => {
                   setShowFingerprint(true);
                 }}
-                left={(props) => <List.Icon {...props} icon="fingerprint" />}
+                icon="fingerprint"
               />
-              <List.Item
-                title="Invitations"
+              <DrawerItem
+                label="Invitations"
+                to="/invitations"
                 onPress={() => {
                   navigation.closeDrawer();
                   navigation.navigate("Invitations");
                 }}
-                left={(props) => <List.Icon {...props} icon="email-outline" />}
+                icon="email-outline"
               />
-              <List.Item
-                title="Logout"
+              <DrawerItem
+                label="Logout"
                 onPress={() => setShowLogout(true)}
                 disabled={syncCount > 0}
-                left={(props) => <List.Icon {...props} icon="exit-to-app" />}
+                icon="exit-to-app"
               />
             </>
           )}
         </>
         <Divider />
-        <List.Section title="External links">
+        <PaperDrawer.Section title="External links">
           {externalMenuItems.map((menuItem) => (
-            <List.Item
+            <DrawerItem
               key={menuItem.title}
-              title={menuItem.title}
+              label={menuItem.title}
+              to={menuItem.link}
               onPress={() => { Linking.openURL(menuItem.link) }}
-              left={(props) => <List.Icon {...props} icon={menuItem.icon} />}
+              icon={menuItem.icon}
             />
           ))}
-        </List.Section>
+        </PaperDrawer.Section>
       </ScrollView>
 
       <FingerprintDialog visible={showFingerprint} onDismiss={() => setShowFingerprint(false)} />

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -9,6 +9,7 @@ export interface Theme extends PaperTheme {
     active: string;
     activeIcon: string;
     activeBackground: string;
+    inactiveIcon: string;
   };
 }
 
@@ -28,6 +29,7 @@ export const LightTheme: Theme = {
     active: Color(mainColors.accent).darken(0.4).rgb().string(),
     activeIcon: Color(mainColors.accent).darken(0.2).rgb().string(),
     activeBackground: Color(mainColors.accent).alpha(0.12).rgb().string(),
+    inactiveIcon: Color(PaperLightTheme.colors.text).alpha(0.68).rgb().string(),
   },
 };
 
@@ -42,6 +44,7 @@ export const DarkTheme: Theme = {
     active: Color(mainColors.accent).lighten(0.4).rgb().string(),
     activeIcon: mainColors.accent,
     activeBackground: Color(mainColors.accent).alpha(0.12).rgb().string(),
+    inactiveIcon: Color(PaperDarkTheme.colors.text).alpha(0.68).rgb().string(),
   },
 };
 

--- a/src/widgets/DrawerItem.tsx
+++ b/src/widgets/DrawerItem.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { DrawerItem as BaseDrawerItem } from "@react-navigation/drawer";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { useTheme } from "../theme";
+
+type PropsType = Omit<React.ComponentProps<typeof BaseDrawerItem>, "icon"> & {
+  disabled?: boolean;
+  icon: string;
+};
+
+export default function DrawerItem(props: PropsType) {
+  const { disabled, icon, onPress, to, ...rest } = props;
+  const { colors } = useTheme();
+
+  return <BaseDrawerItem
+    inactiveTintColor={(disabled) ? colors.disabled : colors.text}
+    icon={({ size }) => (
+      <MaterialCommunityIcons
+        name={icon}
+        color={(disabled) ? colors.disabled : colors.inactiveIcon}
+        size={size}
+      />
+    )}
+    to={(disabled) ? "" : to}
+    onPress={(disabled) ? () => null : onPress}
+    {...rest}
+  />;
+}


### PR DESCRIPTION
This starts the work on #87 and #88.

This PR includes:
- ~A new `Anchor` component that is an improvement from the `Link` element from React Navigation because it is styled according to its focused and hovered state. It is also usable natively in the `Drawer` (`Link` needs a small hack to work where the navigation context is not available). It should only be used on web.~
- ~A new `ListItem` component that uses the `Anchor` and should replace all the `List.Item` elements that have an `onPress`.~
- ~Type declarations for the components I used in `react-native-web` because none are available~
- ~The `Drawer` with the new `ListItem`s. Hovered/focused styles only work on items with links right now. A future PR should add that for the others.~
- The `Drawer` now uses a custom `DrawerItem` derived from React Navigation's `DrawerItem`, that show links on hover.

![Capture d’écran du 2021-01-25 21-58-39](https://user-images.githubusercontent.com/76261501/105766001-7daab680-5f59-11eb-8c89-dd042bb686c7.png)

Tested on web Firefox Linux
Tested on native Android