### PR TITLE
Add feature to share a note

### DIFF
--- a/src/import-export/index.ts
+++ b/src/import-export/index.ts
@@ -1,0 +1,1 @@
+export * from "./share";

--- a/src/import-export/share.native.ts
+++ b/src/import-export/share.native.ts
@@ -1,0 +1,19 @@
+
+import * as Etebase from "etebase";
+import { Share } from "react-native";
+import { getItemData } from "./utils";
+
+export function canShare() {
+  return true;
+}
+
+export async function shareItem(item: Etebase.Item) {
+  const { name, content } = await getItemData(item);
+  
+  // Adding the name as a title at the beginning of the content because it is not shared otherwise
+  const message = `# ${name}\n\n${content}`;
+  await Share.share({
+    message,
+    title: name,
+  });
+}

--- a/src/import-export/share.ts
+++ b/src/import-export/share.ts
@@ -1,0 +1,10 @@
+import * as Etebase from "etebase";
+
+export function canShare() {
+  return false;
+}
+
+export async function shareItem(item: Etebase.Item) {
+  const { name } = item.getMeta();
+  throw Error(`Cannot share item "${name}". Sharing is not implemented on this platform`);
+}

--- a/src/import-export/utils.ts
+++ b/src/import-export/utils.ts
@@ -1,0 +1,10 @@
+import * as Etebase from "etebase";
+
+export async function getItemData(item: Etebase.Item) {
+  const { name } = item.getMeta();
+  const content = await item.getContent(Etebase.OutputFormat.String);
+  return {
+    name,
+    content,
+  };
+}

--- a/src/screens/NoteEditScreen.tsx
+++ b/src/screens/NoteEditScreen.tsx
@@ -24,6 +24,7 @@ import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import NotFound from "../widgets/NotFound";
 import { fontFamilies } from "../helpers";
 import { RootStackParamList } from "../RootStackParamList";
+import { canShare, shareItem } from "../import-export";
 
 type NavigationProp = StackNavigationProp<RootStackParamList, "NoteEdit">;
 
@@ -86,6 +87,7 @@ export default function NoteEditScreen(props: PropsType) {
           onSave={onSave}
           onEdit={() => navigation.navigate("NoteProps", { colUid, itemUid })}
           onDelete={() => setNoteDeleteDialogShow(true)}
+          onShare={onShare}
           changed={changed}
         />
       ),
@@ -169,6 +171,16 @@ export default function NoteEditScreen(props: PropsType) {
     }));
   }
 
+  function onShare() {
+    (async () => {
+      const colMgr = etebase.getCollectionManager();
+      const col = colMgr.cacheLoad(cacheCollections.get(colUid)!.cache);
+      const itemMgr = colMgr.getItemManager(col);
+      const item = itemMgr.cacheLoad(cacheItem!.cache);
+      await shareItem(item);
+    })();
+  }
+
   if (syncGate) {
     return syncGate;
   }
@@ -233,9 +245,10 @@ interface RightActionViewProps {
   onEdit: () => void;
   onSave: () => void;
   onDelete: () => void;
+  onShare: () => void;
 }
 
-function RightAction({ viewMode, setViewMode, onSave, onEdit, onDelete, changed }: RightActionViewProps) {
+function RightAction({ viewMode, setViewMode, onSave, onEdit, onDelete, onShare, changed }: RightActionViewProps) {
   const [showMenu, setShowMenu] = React.useState(false);
 
   return (
@@ -269,6 +282,14 @@ function RightAction({ viewMode, setViewMode, onSave, onEdit, onDelete, changed 
             onSave();
           }}
         />
+        {(canShare()) ? (
+          <Menu.Item icon="share-variant" title="Share"
+            onPress={() => {
+              setShowMenu(false);
+              onShare();
+            }}
+          />
+        ) : null}
       </Menu>
     </View>
   );


### PR DESCRIPTION
This is the beginning towards #24.

- Uses the sharing API of the platform if available to share the content of the note.
- Can be used to export on iOS because it's a native feature of the sharing API.
- Could be used for exporting on Android if the user has an app that can save the file.
- Doesn't work on Web.

Tested on web Firefox Linux (unavailable as expected)
Tested on native Android

Next step: export on Android and Web