### PR TITLE
WIP: Split view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import { DarkTheme, DefaultTheme, Provider as PaperProvider, Colors } from "reac
 
 import { AppearanceProvider, useColorScheme } from "react-native-appearance";
 
-import { NavigationContainer } from "@react-navigation/native";
+import { NavigationContainer, PathConfig } from "@react-navigation/native";
 import { createDrawerNavigator } from "@react-navigation/drawer";
 import RootNavigator from "./RootNavigator";
 
@@ -20,19 +20,17 @@ import "react-native-gesture-handler";
 import { enableScreens } from "react-native-screens";
 import { useSelector } from "react-redux";
 import { StoreState } from "./store";
-import { RootStackParamList } from "./RootStackParamList";
+import { MainStackParamList, RootStackParamList } from "./StacksParamList";
 enableScreens();
 
 const DrawerNavigation = createDrawerNavigator();
 
-type RootStackScreens = {
-  [route in keyof RootStackParamList]: string;
+type StackScreens<T extends RootStackParamList | MainStackParamList> = {
+  [route in keyof T]: string | PathConfig;
 };
 
-const rootStackScreens: RootStackScreens = {
+const mainStackScreens: StackScreens<MainStackParamList> = {
   Home: "notes/:colUid?",
-  Login: "login",
-  Signup: "signup",
   CollectionCreate: "notes/new-notebook",
   CollectionEdit: "notes/:colUid/edit",
   CollectionChangelog: "notes/:colUid/manage",
@@ -41,6 +39,15 @@ const rootStackScreens: RootStackScreens = {
   NoteProps: "notes/:colUid/:itemUid/properties",
   NoteEdit: "notes/:colUid/:itemUid",
   Invitations: "invitations",
+};
+
+const rootStackScreens: StackScreens<RootStackParamList> = {
+  Main: {
+    path: "",
+    screens: mainStackScreens,
+  },
+  Login: "login",
+  Signup: "signup",
   Settings: "settings",
   About: "settings/about",
   DebugLogs: "settings/logs",

--- a/src/Drawer.tsx
+++ b/src/Drawer.tsx
@@ -21,7 +21,7 @@ import LogoutDialog from "./components/LogoutDialog";
 
 import * as C from "./constants";
 import { useCredentials } from "./credentials";
-import { RootStackParamList } from "./RootStackParamList";
+import { MainStackParamList, RootStackParamList } from "./StacksParamList";
 
 type MenuItem = {
   title: string;
@@ -99,11 +99,13 @@ interface PropsType {
   navigation: any;
 }
 
+type AllStacksParamList = RootStackParamList & MainStackParamList;
+
 export default function Drawer(props: PropsType) {
   const [showFingerprint, setShowFingerprint] = React.useState(false);
   const [showLogout, setShowLogout] = React.useState(false);
   const cacheCollections = useSelector((state: StoreState) => state.cache.collections);
-  const navigation = props.navigation as DrawerNavigationProp<RootStackParamList, keyof RootStackParamList>;
+  const navigation = props.navigation as DrawerNavigationProp<AllStacksParamList, keyof AllStacksParamList>;
   const etebase = useCredentials();
   const loggedIn = !!etebase;
   const syncCount = useSelector((state: StoreState) => state.syncCount);

--- a/src/MainNavigator.tsx
+++ b/src/MainNavigator.tsx
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: © 2019 EteSync Authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import * as React from "react";
+import { StyleSheet, View } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import { createStackNavigator } from "@react-navigation/stack";
+import { DrawerNavigationProp } from "@react-navigation/drawer";
+import { Appbar, useTheme } from "react-native-paper";
+
+import PlaceholderScreen from "./screens/PlaceholderScreen";
+import NoteListScreen from "./screens/NoteListScreen";
+import NoteEditScreen from "./screens/NoteEditScreen";
+import NotePropertiesScreen from "./screens/NotePropertiesScreen";
+import CollectionEditScreen from "./screens/CollectionEditScreen";
+import CollectionChangelogScreen from "./screens/CollectionChangelogScreen";
+import CollectionMembersScreen from "./screens/CollectionMembersScreen";
+import InvitationsScreen from "./screens/InvitationsScreen";
+
+import * as C from "./constants";
+import { MainStackParamList } from "./StacksParamList";
+import { useSplitView } from "./helpers";
+
+const MainStack = createStackNavigator<MainStackParamList>();
+
+const MenuButton = React.memo(function MenuButton() {
+  const navigation = useNavigation() as DrawerNavigationProp<any>;
+  return (
+    <Appbar.Action icon="menu" accessibilityLabel="Main menu" onPress={() => navigation.openDrawer()} />
+  );
+});
+
+export default function MainNavigator() {
+  const splitView = useSplitView();
+  const theme = useTheme();
+  return (
+    <View style={styles.container}>
+      {splitView ? (
+        <>
+          <View style={styles.leftScreen}>
+            <NoteListScreen
+              route={{ params: { colUid: "" } }}
+              fixed
+            />
+          </View>
+          <View style={styles.separator} />
+        </>
+      ) : null}
+      <MainStack.Navigator
+        screenOptions={{
+          headerStyle: {
+            backgroundColor: theme.colors.primary,
+          },
+          headerTintColor: "#000000",
+          headerBackTitleVisible: false,
+          headerBackTitleStyle: {
+            backgroundColor: "black",
+          },
+          cardStyle: styles.rightScreen,
+        }}
+      >
+        <MainStack.Screen
+          name="Home"
+          component={splitView ? PlaceholderScreen : NoteListScreen}
+          initialParams={{ colUid: "" }}
+          options={splitView ? {
+            title: "",
+          } : {
+            title: C.appName,
+            headerLeft: () => (
+              <MenuButton />
+            ),
+          }}
+        />
+        <MainStack.Screen
+          name="NoteCreate"
+          component={NotePropertiesScreen}
+        />
+        <MainStack.Screen
+          name="NoteProps"
+          component={NotePropertiesScreen}
+        />
+        <MainStack.Screen
+          name="CollectionEdit"
+          component={CollectionEditScreen}
+        />
+        <MainStack.Screen
+          name="CollectionCreate"
+          component={CollectionEditScreen}
+        />
+        <MainStack.Screen
+          name="CollectionChangelog"
+          component={CollectionChangelogScreen}
+          options={{
+            title: "Manage Notebook",
+          }}
+        />
+        <MainStack.Screen
+          name="CollectionMembers"
+          component={CollectionMembersScreen}
+          options={{
+            title: "Collection Members",
+          }}
+        />
+        <MainStack.Screen
+          name="NoteEdit"
+          component={NoteEditScreen}
+        />
+        <MainStack.Screen
+          name="Invitations"
+          component={InvitationsScreen}
+          options={{
+            title: "Collection Invitations",
+          }}
+        />
+      </MainStack.Navigator>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: "row",
+  },
+  separator: {
+    width: 1,
+    backgroundColor: "black",
+  },
+  leftScreen: {
+    flex: 1,
+    maxWidth: 360,
+  },
+  rightScreen: {
+    flex: 2,
+  },
+});

--- a/src/RootNavigator.tsx
+++ b/src/RootNavigator.tsx
@@ -15,15 +15,9 @@ import SignupScreen from "./screens/SignupScreen";
 import SettingsScreen from "./screens/SettingsScreen";
 import AboutScreen from "./screens/AboutScreen";
 import DebugLogsScreen from "./screens/DebugLogsScreen";
-import NoteListScreen from "./screens/NoteListScreen";
-import NoteEditScreen from "./screens/NoteEditScreen";
-import NotePropertiesScreen from "./screens/NotePropertiesScreen";
-import CollectionEditScreen from "./screens/CollectionEditScreen";
-import CollectionChangelogScreen from "./screens/CollectionChangelogScreen";
-import CollectionMembersScreen from "./screens/CollectionMembersScreen";
-import InvitationsScreen from "./screens/InvitationsScreen";
 import AccountWizardScreen from "./screens/AccountWizardScreen";
 import NotFoundScreen from "./screens/NotFoundScreen";
+import MainNavigator from "./MainNavigator";
 
 import { useCredentials } from "./credentials";
 import { performSync, popMessage } from "./store/actions";
@@ -32,7 +26,7 @@ import { useAppStateCb } from "./helpers";
 
 import * as C from "./constants";
 import { StoreState } from "./store";
-import { RootStackParamList } from "./RootStackParamList";
+import { RootStackParamList } from "./StacksParamList";
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -98,60 +92,13 @@ export default React.memo(function RootNavigator() {
             />
           </>
         ) : (
-          <>
-            <Stack.Screen
-              name="Home"
-              component={NoteListScreen}
-              initialParams={{ colUid: "" }}
-              options={{
-                title: C.appName,
-                headerLeft: () => (
-                  <MenuButton />
-                ),
-              }}
-            />
-            <Stack.Screen
-              name="NoteCreate"
-              component={NotePropertiesScreen}
-            />
-            <Stack.Screen
-              name="NoteProps"
-              component={NotePropertiesScreen}
-            />
-            <Stack.Screen
-              name="CollectionEdit"
-              component={CollectionEditScreen}
-            />
-            <Stack.Screen
-              name="CollectionCreate"
-              component={CollectionEditScreen}
-            />
-            <Stack.Screen
-              name="CollectionChangelog"
-              component={CollectionChangelogScreen}
-              options={{
-                title: "Manage Notebook",
-              }}
-            />
-            <Stack.Screen
-              name="CollectionMembers"
-              component={CollectionMembersScreen}
-              options={{
-                title: "Collection Members",
-              }}
-            />
-            <Stack.Screen
-              name="NoteEdit"
-              component={NoteEditScreen}
-            />
-            <Stack.Screen
-              name="Invitations"
-              component={InvitationsScreen}
-              options={{
-                title: "Collection Invitations",
-              }}
-            />
-          </>
+          <Stack.Screen
+            name="Main"
+            component={MainNavigator}
+            options={{
+              headerShown: false,
+            }}
+          />
         )}
         <Stack.Screen name="Settings" component={SettingsScreen} />
         <Stack.Screen name="About" component={AboutScreen} />

--- a/src/StacksParamList.tsx
+++ b/src/StacksParamList.tsx
@@ -1,10 +1,8 @@
 
 import { StackNavigationProp } from "@react-navigation/stack";
 
-export type RootStackParamList = {
-  Home: { colUid: string };
-  Login: undefined;
-  Signup: undefined;
+export type MainStackParamList = {
+  Home: { colUid: string } | undefined;
   CollectionCreate: undefined;
   CollectionEdit: { colUid: string };
   CollectionChangelog: { colUid: string };
@@ -22,11 +20,19 @@ export type RootStackParamList = {
     itemUid: string;
   };
   Invitations: undefined;
+};
+
+export type RootStackParamList = {
+  Main: undefined;
+  Login: undefined;
+  Signup: undefined;
+  AccountWizard: undefined;
   Settings: undefined;
   About: undefined;
   DebugLogs: undefined;
-  AccountWizard: undefined;
   "404": undefined;
 };
 
-export type DefaultNavigationProp = StackNavigationProp<RootStackParamList, keyof RootStackParamList>;
+export type RootNavigationProp = StackNavigationProp<RootStackParamList, keyof RootStackParamList>;
+
+export type MainNavigationProp = StackNavigationProp<MainStackParamList, keyof MainStackParamList>;

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as React from "react";
-import { AppState, AppStateStatus, Platform } from "react-native";
+import { AppState, AppStateStatus, Platform, useWindowDimensions } from "react-native";
 import * as Etebase from "etebase";
 
 import { logger } from "./logging";
@@ -172,3 +172,16 @@ export const fontFamilies = Platform.select({
     serif: "serif",
   },
 });
+
+const BREAKPOINT = 900;
+
+export function useSplitView() {
+  const { width } = useWindowDimensions();
+  const [splitView, setSplitView] = React.useState(false);
+
+  React.useEffect(() => {
+    if (width < BREAKPOINT) { setSplitView(false) } else { setSplitView(true) }
+  }, [width]);
+
+  return splitView;
+}

--- a/src/screens/AccountWizardScreen.tsx
+++ b/src/screens/AccountWizardScreen.tsx
@@ -21,7 +21,7 @@ import { useDispatch } from "react-redux";
 import { performSync } from "../store/actions";
 
 import * as C from "../constants";
-import { RootStackParamList } from "../RootStackParamList";
+import { RootStackParamList } from "../StacksParamList";
 
 const wizardPages = [
   (props: PagePropsType) => (
@@ -130,7 +130,7 @@ export default function AccountWizardScreen() {
 
   React.useEffect(() => {
     if (!syncError && !syncGate && ranWizard) {
-      navigation.navigate("Home", { colUid: "" });
+      navigation.navigate("Main");
     }
   }, [ranWizard, syncError, syncGate]);
 

--- a/src/screens/CollectionChangelogScreen.tsx
+++ b/src/screens/CollectionChangelogScreen.tsx
@@ -18,17 +18,17 @@ import { Title } from "../widgets/Typography";
 import NotFound from "../widgets/NotFound";
 
 import { defaultColor } from "../helpers";
-import { DefaultNavigationProp, RootStackParamList } from "../RootStackParamList";
+import { MainNavigationProp, MainStackParamList } from "../StacksParamList";
 
 import ColorBox from "../widgets/ColorBox";
 
 const iconDeleted = (props: any) => (<List.Icon {...props} color="#F20C0C" icon="delete" />);
 const iconChanged = (props: any) => (<List.Icon {...props} color="#FEB115" icon="pencil" />);
 
-type NavigationProp = StackNavigationProp<RootStackParamList, "CollectionChangelog">;
+type NavigationProp = StackNavigationProp<MainStackParamList, "CollectionChangelog">;
 
 interface PropsType {
-  route: RouteProp<RootStackParamList, "CollectionChangelog">;
+  route: RouteProp<MainStackParamList, "CollectionChangelog">;
 }
 
 export default function CollectionChangelogScreen(props: PropsType) {
@@ -114,7 +114,7 @@ export default function CollectionChangelogScreen(props: PropsType) {
 
 function RightAction(props: { colUid: string }) {
   const [showMenu, setShowMenu] = React.useState(false);
-  const navigation = useNavigation<DefaultNavigationProp>();
+  const navigation = useNavigation<MainNavigationProp>();
   const colUid = props.colUid;
 
   return (

--- a/src/screens/CollectionEditScreen.tsx
+++ b/src/screens/CollectionEditScreen.tsx
@@ -22,7 +22,7 @@ import ErrorOrLoadingDialog from "../widgets/ErrorOrLoadingDialog";
 import NotFound from "../widgets/NotFound";
 
 import { useLoading, defaultColor } from "../helpers";
-import { DefaultNavigationProp, RootStackParamList } from "../RootStackParamList";
+import { MainNavigationProp, MainStackParamList } from "../StacksParamList";
 
 import ColorPicker from "../widgets/ColorPicker";
 import * as C from "../constants";
@@ -32,10 +32,10 @@ interface FormErrors {
   color?: string;
 }
 
-type NavigationProp = StackNavigationProp<RootStackParamList, "CollectionEdit"> | StackNavigationProp<RootStackParamList, "CollectionCreate">;
+type NavigationProp = StackNavigationProp<MainStackParamList, "CollectionEdit"> | StackNavigationProp<MainStackParamList, "CollectionCreate">;
 
 interface PropsType {
-  route: RouteProp<RootStackParamList, "CollectionEdit"> | RouteProp<RootStackParamList, "CollectionCreate">;
+  route: RouteProp<MainStackParamList, "CollectionEdit"> | RouteProp<MainStackParamList, "CollectionCreate">;
 }
 
 export default function CollectionEditScreen(props: PropsType) {
@@ -212,7 +212,7 @@ export default function CollectionEditScreen(props: PropsType) {
 
 function RightAction(props: { colUid: string | undefined }) {
   const [confirmationVisible, setConfirmationVisible] = React.useState(false);
-  const navigation = useNavigation<DefaultNavigationProp>();
+  const navigation = useNavigation<MainNavigationProp>();
   const etebase = useCredentials()!;
   const dispatch = useAsyncDispatch();
   const cacheCollections = useSelector((state: StoreState) => state.cache.collections);

--- a/src/screens/CollectionMembersScreen.tsx
+++ b/src/screens/CollectionMembersScreen.tsx
@@ -21,12 +21,12 @@ import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import ErrorDialog from "../widgets/ErrorDialog";
 import NotFound from "../widgets/NotFound";
 import CollectionMemberAddDialog from "../components/CollectionMemberAddDialog";
-import { RootStackParamList } from "../RootStackParamList";
+import { MainStackParamList } from "../StacksParamList";
 
-type NavigationProp = StackNavigationProp<RootStackParamList, "CollectionMembers">;
+type NavigationProp = StackNavigationProp<MainStackParamList, "CollectionMembers">;
 
 interface PropsType {
-  route: RouteProp<RootStackParamList, "CollectionMembers">;
+  route: RouteProp<MainStackParamList, "CollectionMembers">;
 }
 
 

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -24,7 +24,7 @@ import { useCredentials } from "../credentials";
 import LinkButton from "../widgets/LinkButton";
 import { useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
-import { RootStackParamList } from "../RootStackParamList";
+import { RootStackParamList } from "../StacksParamList";
 
 type NavigationProp = StackNavigationProp<RootStackParamList, "Login">;
 

--- a/src/screens/NoteEditScreen.tsx
+++ b/src/screens/NoteEditScreen.tsx
@@ -23,12 +23,12 @@ import Menu from "../widgets/Menu";
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import NotFound from "../widgets/NotFound";
 import { fontFamilies } from "../helpers";
-import { RootStackParamList } from "../RootStackParamList";
+import { MainStackParamList } from "../StacksParamList";
 
-type NavigationProp = StackNavigationProp<RootStackParamList, "NoteEdit">;
+type NavigationProp = StackNavigationProp<MainStackParamList, "NoteEdit">;
 
 interface PropsType {
-  route: RouteProp<RootStackParamList, "NoteEdit">;
+  route: RouteProp<MainStackParamList, "NoteEdit">;
 }
 
 export default function NoteEditScreen(props: PropsType) {

--- a/src/screens/NoteListScreen.tsx
+++ b/src/screens/NoteListScreen.tsx
@@ -17,7 +17,8 @@ import { useCredentials } from "../credentials";
 
 import Menu from "../widgets/Menu";
 import NotFound from "../widgets/NotFound";
-import { DefaultNavigationProp, RootStackParamList } from "../RootStackParamList";
+import { MainNavigationProp, MainStackParamList } from "../StacksParamList";
+import { DrawerNavigationProp } from "@react-navigation/drawer";
 
 
 function sortMtime(aIn: CachedItem, bIn: CachedItem) {
@@ -58,10 +59,18 @@ function getSortFunction(sortOrder: string) {
   };
 }
 
-type NavigationProp = StackNavigationProp<RootStackParamList, "Home">;
+const MenuButton = React.memo(function MenuButton() {
+  const navigation = useNavigation() as DrawerNavigationProp<any>;
+  return (
+    <Appbar.Action icon="menu" accessibilityLabel="Main menu" onPress={() => navigation.openDrawer()} />
+  );
+});
+
+type NavigationProp = StackNavigationProp<MainStackParamList, "Home">;
 
 interface PropsType {
-  route: RouteProp<RootStackParamList, "Home">;
+  route: Partial<RouteProp<MainStackParamList, "Home">>;
+  fixed?: boolean;
 }
 
 export default function NoteListScreen(props: PropsType) {
@@ -73,17 +82,19 @@ export default function NoteListScreen(props: PropsType) {
   const syncGate = useSyncGate();
   const theme = useTheme();
 
+  const fixed = props.fixed;
   const colUid = props.route.params?.colUid || undefined;
   const cacheCollection = (colUid) ? cacheCollections.get(colUid) : undefined;
 
   React.useEffect(() => {
-
-    navigation.setOptions({
-      title: cacheCollection?.meta.name ?? "All Notes",
-      headerRight: () => (
-        <RightAction colUid={colUid} />
-      ),
-    });
+    if (!fixed) {
+      navigation.setOptions({
+        title: cacheCollection?.meta.name ?? "All Notes",
+        headerRight: () => (
+          <RightAction colUid={colUid} />
+        ),
+      });
+    }
   }, [navigation, cacheCollections, colUid]);
 
   const entriesList = React.useMemo(() => {
@@ -131,6 +142,13 @@ export default function NoteListScreen(props: PropsType) {
 
   return (
     <>
+      {fixed ? (
+        <Appbar.Header style={{ flex: 0 }}>
+          <MenuButton />
+          <Appbar.Content title={cacheCollection?.meta.name ?? "All Notes"} />
+          <Appbar.Action icon="dots-vertical" onPress={() => { return }} />
+        </Appbar.Header>
+      ) : null}
       <FlatList
         style={[{ backgroundColor: theme.colors.background }, { flex: 1 }]}
         data={entriesList}
@@ -176,7 +194,7 @@ function RightAction(props: RightActionPropsType) {
   const isSyncing = useSelector((state: StoreState) => state.syncCount) > 0;
   const selecetdStyle = { color: "green" };
   const viewSettings = useSelector((state: StoreState) => state.settings.viewSettings);
-  const navigation = useNavigation<DefaultNavigationProp>();
+  const navigation = useNavigation<MainNavigationProp>();
   const { colUid } = props;
 
   function setShowSortMenu(value: boolean) {

--- a/src/screens/NotePropertiesScreen.tsx
+++ b/src/screens/NotePropertiesScreen.tsx
@@ -24,17 +24,17 @@ import TextInputWithIcon from "../widgets/TextInputWithIcon";
 import NotFound from "../widgets/NotFound";
 
 import { useLoading, NoteMetadata } from "../helpers";
-import { RootStackParamList } from "../RootStackParamList";
+import { MainStackParamList } from "../StacksParamList";
 
 interface FormErrors {
   name?: string;
   notebook?: string;
 }
 
-type NavigationProp = StackNavigationProp<RootStackParamList, "NoteProps"> | StackNavigationProp<RootStackParamList, "NoteCreate">;
+type NavigationProp = StackNavigationProp<MainStackParamList, "NoteProps"> | StackNavigationProp<MainStackParamList, "NoteCreate">;
 
 interface PropsType {
-  route: RouteProp<RootStackParamList, "NoteProps"> | RouteProp<RootStackParamList, "NoteCreate">;
+  route: RouteProp<MainStackParamList, "NoteProps"> | RouteProp<MainStackParamList, "NoteCreate">;
 }
 
 export default function NotePropertiesScreen(props: PropsType) {

--- a/src/screens/PlaceholderScreen.tsx
+++ b/src/screens/PlaceholderScreen.tsx
@@ -1,23 +1,24 @@
 import * as React from "react";
 import { useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
-import { RootStackParamList } from "../StacksParamList";
+import { MainStackParamList } from "../StacksParamList";
 import NotFound from "../widgets/NotFound";
 
-type NavigationProp = StackNavigationProp<RootStackParamList, "404">;
+type NavigationProp = StackNavigationProp<MainStackParamList, "Home">;
 
-export default function NotFoundScreen() {
+export default function PlaceholderScreen() {
   const navigation = useNavigation<NavigationProp>();
 
   React.useEffect(() => {
     navigation.setOptions({
-      title: "Page Not Found",
+      title: "",
     });
   }, [navigation]);
 
   return (
     <NotFound
-      message="Sorry, we couldn't find this page"
+      message="Select a note on the left"
+      help=""
     />
   );
 }

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -28,7 +28,7 @@ import { StackNavigationProp } from "@react-navigation/stack";
 import Alert from "../widgets/Alert";
 import FontSelector from "../widgets/FontSelector";
 import Select from "../widgets/Select";
-import { RootStackParamList } from "../RootStackParamList";
+import { RootStackParamList } from "../StacksParamList";
 
 interface DialogPropsType {
   visible: boolean;

--- a/src/screens/SignupScreen.tsx
+++ b/src/screens/SignupScreen.tsx
@@ -26,7 +26,7 @@ import { useCredentials } from "../credentials";
 import LinkButton from "../widgets/LinkButton";
 import { useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
-import { RootStackParamList } from "../RootStackParamList";
+import { RootStackParamList } from "../StacksParamList";
 
 interface FormErrors {
   username?: string;


### PR DESCRIPTION
This is a first draft for #34 to have your opinion on what's happening so far.
I believe I chose the configuration that would be the simplest and cleanest (though a bit messy for my taste)…

So I propose to introduce a nested `MainStack` that can show the Notes List at the left of its Screens if there's enough space. An advantage is that by default it doesn't break the actual behavior of the app. An inconvenient is that there's a lot of small file changes because of the types (otherwise most files would be untouched).

The code as it is kinda works and is not polished:

- [ ] **Notebook Selection**
The notebook selection is not implemented. We can't use the URL to change the notebook. This makes the navigator navigate to Home, so the screen on the right doesn't stay open. Plus it's a weird behavior to have the URL change when only the list changes.
It is also difficult to send data from the Drawer to the Notes List Screen. We could use a Context but that's seems exaggerated just for this.
A solution could be to have the Notebook selection as a dropdown when clicking the title in the Header Bar: we don't need to involve the URL as it's already part of the screen.

- [ ] **Selection**
Of course the selected (open) note should be highlighted in the Notes List.

- [x] **Header Bar**
The header bar style is not consistent between React Native Paper and React Navigation but it can easily be fixed.

- [ ] **Right Action**
The `RightAction` component seems to create a loop if I include it in the Header so the page never finishes to render. I didn't investigate this for now.

I mostly want to know if it's worth pursuing that direction.

![Capture d’écran du 2021-01-16 18-43-34](https://user-images.githubusercontent.com/76261501/104818974-1723eb00-582b-11eb-8bc3-60097fcc3a73.png)
