### PR TITLE
Fix crash when going back from CollectionEdit

### DIFF
--- a/src/screens/CollectionEditScreen.tsx
+++ b/src/screens/CollectionEditScreen.tsx
@@ -47,7 +47,8 @@ export default function CollectionEditScreen(props: PropsType) {
   const cacheCollections = useSelector((state: StoreState) => state.cache.collections);
   const syncGate = useSyncGate();
   const navigation = useNavigation<NavigationProp>();
-  const navigationState = (navigation.canGoBack()) ? useNavigationState((state) => state.routes[state.index - 1]) : null;
+  const navigationState_ = useNavigationState((state) => state.routes[state.index - 1]);
+  const navigationState = (navigation.canGoBack()) ? navigationState_ : null;
   const etebase = useCredentials()!;
   const [loading, error, setPromise] = useLoading();
   const colType = C.colType;


### PR DESCRIPTION
When going to the "new notebook" screen, then going back with the arrow or the Android button, the app crashed.

This was a rookie mistake introduced by me in fbf3ccef71d0374e078e497e015db09435a387cf : a hook was behind an if clause so the hooks number would change.

Tested on native Android