### PR TITLE
Use a local copy of Workbox

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,14 @@ module.exports = async function (env, argv) {
       // Passing true will enable the default Workbox + Expo SW configuration.
       offline: true,
     },
-    argv
+    {
+      ...argv,
+      workbox: {
+        generateSWOptions: {
+          importWorkboxFrom: "local",
+        },
+      },
+    }
   );
   // Customize the config before returning it.
   return config;


### PR DESCRIPTION
This avoids having to change Content Security Policy to trust Google's CDN.