### PR TITLE
Actually fix canGoBack for CollectionEditScreen

### DIFF
--- a/src/screens/CollectionEditScreen.tsx
+++ b/src/screens/CollectionEditScreen.tsx
@@ -47,8 +47,7 @@ export default function CollectionEditScreen(props: PropsType) {
   const cacheCollections = useSelector((state: StoreState) => state.cache.collections);
   const syncGate = useSyncGate();
   const navigation = useNavigation<NavigationProp>();
-  const navigationState_ = useNavigationState((state) => state.routes[state.index - 1]);
-  const navigationState = (navigation.canGoBack()) ? navigationState_ : null;
+  const navigationState = useNavigationState((state) => (state.index > 0) ? state.routes[state.index - 1] : null);
   const etebase = useCredentials()!;
   const [loading, error, setPromise] = useLoading();
   const colType = C.colType;


### PR DESCRIPTION
It turns out #107 was not the correct fix because it made the if statement useless.