### PR TITLE
Generalize goBack feature for CollectionCreate

### DIFF
--- a/src/RootStackParamList.tsx
+++ b/src/RootStackParamList.tsx
@@ -2,7 +2,7 @@
 import { StackNavigationProp } from "@react-navigation/stack";
 
 export type RootStackParamList = {
-  Home: undefined;
+  Home: { colUid: string } | undefined;
   Login: undefined;
   Signup: undefined;
   CollectionCreate: undefined;

--- a/src/screens/CollectionEditScreen.tsx
+++ b/src/screens/CollectionEditScreen.tsx
@@ -5,13 +5,13 @@ import * as React from "react";
 import { useSelector } from "react-redux";
 import { TextInput as NativeTextInput } from "react-native";
 import { HelperText, Paragraph } from "react-native-paper";
-import { useNavigation, RouteProp, useNavigationState, CommonActions } from "@react-navigation/native";
+import { useNavigation, RouteProp } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 
 import { useSyncGate } from "../SyncGate";
 import { useCredentials } from "../credentials";
 import { StoreState, useAsyncDispatch } from "../store";
-import { collectionUpload, pushMessage } from "../store/actions";
+import { collectionUpload, pushMessage, setActiveNotebook } from "../store/actions";
 
 import TextInput from "../widgets/TextInput";
 import ScrollView from "../widgets/ScrollView";
@@ -48,7 +48,6 @@ export default function CollectionEditScreen(props: PropsType) {
   const cacheCollections = useSelector((state: StoreState) => state.cache.collections);
   const syncGate = useSyncGate();
   const navigation = useNavigation<NavigationProp>();
-  const navigationState = useNavigationState((state) => (state.index > 0) ? state.routes[state.index - 1] : null);
   const etebase = useCredentials()!;
   const [loading, error, setPromise] = useLoading();
   const colType = C.colType;
@@ -126,17 +125,12 @@ export default function CollectionEditScreen(props: PropsType) {
         navigation.goBack();
       } else {
         dispatch(pushMessage({ message: "Notebook created", severity: "success" }));
+        dispatch(setActiveNotebook({ meta, uid: collection.uid }));
 
-        const previousScreen = navigationState?.name;
-        if (navigationState && previousScreen === "NoteCreate") {
-          // We change the colUid 
-          navigation.dispatch({
-            ...CommonActions.setParams({ colUid: collection.uid }),
-            source: navigationState.key,
-          });
+        if (navigation.canGoBack()) {
+          navigation.goBack();
         } else {
-          // We're gonna navigate to the notebook's page
-          navigation.replace("Collection", { colUid: collection.uid });
+          navigation.replace("Home");
         }
       }
     });

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -6,7 +6,7 @@ import { createAction as origCreateAction, ActionMeta } from "redux-actions";
 import * as Etebase from "etebase";
 
 import { ConnectionInfo, SettingsType } from "./";
-import { Message } from "./reducers";
+import { Message, Notebook } from "./reducers";
 
 type FunctionAny = (...args: any[]) => any;
 
@@ -243,5 +243,16 @@ export const setSettings = createAction(
   "SET_SETTINGS",
   (settings: Partial<SettingsType>) => {
     return { ...settings };
+  }
+);
+
+export const setActiveNotebook = createAction(
+  "SET_ACTIVE_NOTEBOOK",
+  (activeNotebook: Notebook | undefined) => {
+    if (activeNotebook) {
+      return { ...activeNotebook };
+    } else {
+      return null;
+    }
   }
 );

--- a/src/store/construct.ts
+++ b/src/store/construct.ts
@@ -14,9 +14,9 @@ import { List, Map as ImmutableMap } from "immutable";
 
 import {
   SettingsType,
-  fetchCount, syncCount, credentials, settingsReducer, syncStatusReducer, lastSyncReducer, connectionReducer, errorsReducer,
+  fetchCount, syncCount, credentials, settingsReducer, syncStatusReducer, lastSyncReducer, connectionReducer, errorsReducer, activeNotebookReducer,
   CredentialsData, SyncCollectionsData, SyncGeneralData,
-  collections, items, syncCollections, syncItems, syncGeneral, CachedCollectionsData, CachedItemsData, SyncItemsData, messagesReducer, Message,
+  collections, items, syncCollections, syncItems, syncGeneral, CachedCollectionsData, CachedItemsData, SyncItemsData, messagesReducer, Message, Notebook,
 } from "./reducers";
 
 export interface StoreState {
@@ -39,6 +39,7 @@ export interface StoreState {
   connection: NetInfoStateType | null;
   errors: List<Error>;
   messages: List<Message>;
+  activeNotebook: Notebook;
 }
 
 const settingsMigrations = {
@@ -168,6 +169,7 @@ const reducers = combineReducers({
   connection: connectionReducer,
   errors: errorsReducer,
   messages: messagesReducer,
+  activeNotebook: activeNotebookReducer,
 });
 
 export default reducers;

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -369,3 +369,17 @@ export const settingsReducer = handleActions(
     },
   }
 );
+
+export type Notebook = {
+  meta: Etebase.ItemMetadata;
+  uid: string;
+};
+
+export const activeNotebookReducer = handleActions(
+  {
+    [actions.setActiveNotebook.toString()]: (_state: Notebook | null, action: Action<Notebook | null>) => {
+      return action.payload;
+    },
+  },
+  null
+);


### PR DESCRIPTION
Instead of relying on the name of the previous screen to send the newly created `colUid` back, we use a route param. This will allow to have the same behavior on other screens.

Fixes #156

Tested on web Firefox Linux
Tested on native Android