### PR TITLE
Default to first Notebook option if available

### DIFF
--- a/src/screens/NotePropertiesScreen.tsx
+++ b/src/screens/NotePropertiesScreen.tsx
@@ -52,7 +52,7 @@ export default function NotePropertiesScreen(props: PropsType) {
       .sort((a, b) => (a.meta!.name!.toUpperCase() >= b.meta!.name!.toUpperCase()) ? 1 : -1)
       .values()
   );
-  const [collection, setCollection] = React.useState<typeof options[0] | undefined>();
+  const [collection, setCollection] = React.useState((options.length > 0) ? options[0] : undefined);
   const syncGate = useSyncGate();
   const navigation = useNavigation<NavigationProp>();
   const etebase = useCredentials()!;


### PR DESCRIPTION
This was a regression introduced in fbf3ccef71d0374e078e497e015db09435a387cf when switching from NoteEditDialog to NotePropertiesScreen.

Tested on web Firefox Linux
Tested on native Android