### PR TITLE
Remove react-native-appearance dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "0.63.4",
-    "react-native-appearance": "~0.3.3",
     "react-native-etebase": "^0.1.5",
     "react-native-gesture-handler": "~1.7.0",
     "react-native-get-random-values": "^1.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as React from "react";
-import { StatusBar } from "react-native";
+import { StatusBar, useColorScheme } from "react-native";
 import { DarkTheme, DefaultTheme, Provider as PaperProvider, Colors } from "react-native-paper";
-
-import { AppearanceProvider, useColorScheme } from "react-native-appearance";
 
 import { NavigationContainer } from "@react-navigation/native";
 import { createDrawerNavigator } from "@react-navigation/drawer";
@@ -102,10 +100,8 @@ class App extends React.Component {
   public render() {
     return (
       <SafeAreaProvider>
-        <AppearanceProvider>
-          <StatusBar barStyle="dark-content" translucent backgroundColor="transparent" />
-          <InnerApp />
-        </AppearanceProvider>
+        <StatusBar barStyle="dark-content" translucent backgroundColor="transparent" />
+        <InnerApp />
       </SafeAreaProvider>
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10883,15 +10883,6 @@ react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-native-appearance@~0.3.3:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/react-native-appearance/-/react-native-appearance-0.3.4.tgz#2cbcbc5142cdc1898c116684f519b16c879cbec2"
-  integrity sha512-Vz3zdJbAEiMDwuw6wH98TT1WVfBvWjvANutYtkIbl16KGRCigtSgt6IIiLsF3/TSS3y3FtHhWDelFeGw/rtuig==
-  dependencies:
-    fbemitter "^2.1.1"
-    invariant "^2.2.4"
-    use-subscription "^1.0.0"
-
 react-native-etebase@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/react-native-etebase/-/react-native-etebase-0.1.5.tgz#0f19f03968f46caf1aafc317e7a24e5ab8718e16"


### PR DESCRIPTION
This is now handled by [React Native's Appearance API](https://reactnative.dev/docs/appearance).

Tested on web Firefox Linux
Tested on Android