### PR TITLE
Improve light theme contrast for accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/drawer": "^5.9.1",
     "@react-navigation/native": "^5.7.4",
     "@react-navigation/stack": "^5.9.1",
+    "color": "^3.1.3",
     "etebase": "^0.41.0",
     "expo-background-fetch": "^8.6.0",
     "expo-font": "^8.3.0",
@@ -57,6 +58,7 @@
   "devDependencies": {
     "@babel/core": "~7.9.0",
     "@expo/webpack-config": "^0.12.53",
+    "@types/color": "^3.0.1",
     "@types/markdown-it": "^12.0.0",
     "@types/react": "~16.9.35",
     "@types/react-dom": "~16.9.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@
 
 import * as React from "react";
 import { StatusBar, useColorScheme } from "react-native";
-import { DarkTheme, DefaultTheme, Provider as PaperProvider, Colors } from "react-native-paper";
+import { DarkTheme, DefaultTheme, Provider as PaperProvider } from "react-native-paper";
 
 import { NavigationContainer } from "@react-navigation/native";
 import { createDrawerNavigator } from "@react-navigation/drawer";
@@ -19,6 +19,8 @@ import { enableScreens } from "react-native-screens";
 import { useSelector } from "react-redux";
 import { StoreState } from "./store";
 import { RootStackParamList } from "./RootStackParamList";
+import { extraColors, mainColors, Theme } from "./theme";
+
 enableScreens();
 
 const DrawerNavigation = createDrawerNavigator();
@@ -68,13 +70,13 @@ function InnerApp() {
   const colorScheme = (darkModePreference === "auto") ? colorScheme_ : darkModePreference;
   const baseTheme = (colorScheme === "dark") ? DarkTheme : DefaultTheme;
 
-  const theme: typeof DefaultTheme = {
+  const theme: Theme = {
     ...baseTheme,
     mode: "exact",
     colors: {
       ...baseTheme.colors,
-      primary: Colors.amber500,
-      accent: Colors.lightBlueA700, // Not the real etesync theme but better for accessibility
+      ...mainColors,
+      ...extraColors,
     },
   };
 

--- a/src/screens/AboutScreen.tsx
+++ b/src/screens/AboutScreen.tsx
@@ -3,13 +3,14 @@
 
 import * as React from "react";
 import { Linking, FlatList } from "react-native";
-import { Text, List, TouchableRipple, useTheme } from "react-native-paper";
+import { Text, List, TouchableRipple } from "react-native-paper";
 
 import { Title } from "../widgets/Typography";
 import Container from "../widgets/Container";
 
 import { expo } from "../../app.json";
 import * as C from "../constants";
+import { useTheme } from "../theme";
 
 import * as licenses from "../../licenses.json";
 
@@ -42,7 +43,7 @@ export default function AboutScreen() {
         <Container>
           <Title style={{ textAlign: "center" }}>{C.appName} {expo.version}</Title>
           <TouchableRipple onPress={() => { Linking.openURL(C.homePage) }}>
-            <Text style={{ textAlign: "center", color: theme.colors.accent, textDecorationLine: "underline", margin: 10 }}>{C.homePage}</Text>
+            <Text style={{ textAlign: "center", color: theme.colors.accentText, textDecorationLine: "underline", margin: 10 }}>{C.homePage}</Text>
           </TouchableRipple>
           <Title style={{ marginTop: 30 }}>Open Source Licenses</Title>
         </Container>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,22 @@
+import { Colors, useTheme as usePaperTheme } from "react-native-paper";
+import { Theme as PaperTheme } from "react-native-paper/lib/typescript/types";
+import Color from "color";
+
+export interface Theme extends PaperTheme {
+  colors: PaperTheme["colors"] & {
+    accentText: string;
+  };
+}
+
+export const mainColors = {
+  primary: Colors.amber500,
+  accent: Colors.lightBlueA700, // Not the real etesync theme but better for accessibility
+};
+
+export const extraColors = {
+  accentText: Color(mainColors.accent).darken(0.2).rgb().string(),
+};
+
+export function useTheme() {
+  return usePaperTheme() as Theme;
+}

--- a/src/widgets/ConfirmationDialog.tsx
+++ b/src/widgets/ConfirmationDialog.tsx
@@ -3,9 +3,10 @@
 
 import * as React from "react";
 import { Keyboard, Platform, ScrollView } from "react-native";
-import { Card, Portal, Modal, Button, ProgressBar, Paragraph, useTheme, Dialog } from "react-native-paper";
+import { Card, Portal, Modal, Button, ProgressBar, Paragraph, Dialog } from "react-native-paper";
 
 import { isPromise, useIsMounted } from "../helpers";
+import { useTheme } from "../theme";
 
 interface PropsType {
   title: string;
@@ -30,7 +31,7 @@ export default React.memo(function ConfirmationDialog(props: PropsType) {
   const labelCancel = props.labelCancel ?? "Cancel";
   const labelOk = props.labelOk ?? "OK";
   const loadingText = props.loadingText ?? "Loading...";
-  const buttonThemeOverride = { colors: { primary: theme.colors.accent } };
+  const buttonThemeOverride = { colors: { primary: theme.colors.accentText } };
 
   React.useEffect(() => {
     Keyboard.dismiss();

--- a/src/widgets/ExternalLink.tsx
+++ b/src/widgets/ExternalLink.tsx
@@ -3,8 +3,10 @@
 
 import * as React from "react";
 import { ViewProps, Linking } from "react-native";
-import { Text, useTheme } from "react-native-paper";
+import { Text } from "react-native-paper";
+
 import LinkButton from "./LinkButton";
+import { useTheme } from "../theme";
 
 type PropsType = {
   href: string;
@@ -19,7 +21,7 @@ export default function ExternalLink(props_: React.PropsWithChildren<PropsType>)
       {...props}
       onPress={() => Linking.openURL(href)}
     >
-      <Text style={{ color: theme.colors.accent }}>{children}</Text>
+      <Text style={{ color: theme.colors.accentText }}>{children}</Text>
     </LinkButton>
   );
 }

--- a/src/widgets/LinkButton.tsx
+++ b/src/widgets/LinkButton.tsx
@@ -3,7 +3,8 @@
 
 import * as React from "react";
 import { ViewProps } from "react-native";
-import { Text, TouchableRipple, useTheme } from "react-native-paper";
+import { Text, TouchableRipple } from "react-native-paper";
+import { useTheme } from "../theme";
 
 type PropsType = {
   onPress: () => void;
@@ -19,7 +20,7 @@ export default function LinkButton(props_: React.PropsWithChildren<PropsType>) {
       {...props}
       onPress={onPress}
     >
-      <Text style={{ color: theme.colors.accent }}>{children}</Text>
+      <Text style={{ color: theme.colors.accentText }}>{children}</Text>
     </TouchableRipple>
   );
 }

--- a/src/widgets/TextInput.tsx
+++ b/src/widgets/TextInput.tsx
@@ -17,6 +17,7 @@ export default React.memo(React.forwardRef(function PasswordInput(inProps: React
       style={[{ backgroundColor: "transparent" }, style]}
       autoCorrect={false}
       theme={{ colors: { primary: theme.colors.placeholder } }}
+      selectionColor=""
       {...props}
     />
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2829,6 +2829,25 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/color-convert@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"
+  integrity sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==
+  dependencies:
+    "@types/color-name" "*"
+
+"@types/color-name@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/color@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.1.tgz#2900490ed04da8116c5058cd5dba3572d5a25071"
+  integrity sha512-oeUWVaAwI+xINDUx+3F2vJkl/vVB03VChFF/Gl3iQCdbcakjuoJyMOba+3BXRtnBhxZ7uBYqQBi9EpLnvSoztA==
+  dependencies:
+    "@types/color-convert" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"


### PR DESCRIPTION
I just needed to darken the color when text was using the accent color.
I used the `color` package that is already used by React Navigation and React Native Paper to avoid adding a new dependency.

Tested on web Firefox Linux
Tested on native Android