### PR TITLE
Set width of dialog according to screen width

### DIFF
--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as React from "react";
-import { AppState, AppStateStatus, Platform } from "react-native";
+import { AppState, AppStateStatus, Platform, useWindowDimensions } from "react-native";
 import * as Etebase from "etebase";
 
 import { logger } from "./logging";
@@ -172,3 +172,16 @@ export const fontFamilies = Platform.select({
     serif: "serif",
   },
 });
+
+const widescreenBreakPoint = 960;
+
+export function useWidescreen() {
+  const { width } = useWindowDimensions();
+  const [widescreen, setWidescreen] = React.useState(false);
+
+  React.useEffect(() => {
+    (width < widescreenBreakPoint) ? setWidescreen(false) : setWidescreen(true);
+  }, [width]);
+
+  return widescreen;
+}

--- a/src/widgets/ConfirmationDialog.tsx
+++ b/src/widgets/ConfirmationDialog.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { Keyboard, Platform, ScrollView } from "react-native";
 import { Card, Portal, Modal, Button, ProgressBar, Paragraph, Dialog } from "react-native-paper";
 
-import { isPromise, useIsMounted } from "../helpers";
+import { isPromise, useIsMounted, useWidescreen } from "../helpers";
 import { useTheme } from "../theme";
 
 interface PropsType {
@@ -32,6 +32,7 @@ export default React.memo(function ConfirmationDialog(props: PropsType) {
   const labelOk = props.labelOk ?? "OK";
   const loadingText = props.loadingText ?? "Loading...";
   const buttonThemeOverride = { colors: { primary: theme.colors.accentText } };
+  const widescreen = useWidescreen();
 
   React.useEffect(() => {
     Keyboard.dismiss();
@@ -90,7 +91,7 @@ export default React.memo(function ConfirmationDialog(props: PropsType) {
           visible={props.visible}
           onDismiss={props.onCancel}
           dismissable={props.dismissable && !loading}
-          style={{ maxHeight: "100%" }}
+          style={{ maxHeight: "100%", alignSelf: "center", width: widescreen ? 560 : 280, maxWidth: "100%" }}
         >
           <ScrollView>
             <Dialog.Title>
@@ -114,7 +115,8 @@ export default React.memo(function ConfirmationDialog(props: PropsType) {
         visible={props.visible}
         onDismiss={props.onCancel}
         dismissable={props.dismissable && !loading}
-        style={{ maxHeight: "100%" }}
+        style={{ alignItems: "center" }}
+        contentContainerStyle={{ maxHeight: "100%", width: widescreen ? 560 : 280, maxWidth: "100%" }}
       >
         <ScrollView>
           <Card accessible={false}>


### PR DESCRIPTION
This follows the [Material Guidelines for dialogs](https://material.io/components/dialogs#specs).

Tested on web Firefox Linux
Tested on native Android