### PR TITLE
Use an "adaptive" dark theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ function InnerApp() {
 
   return (
     <PaperProvider theme={theme}>
+      <StatusBar barStyle={theme.dark ? "light-content" : "dark-content"} translucent backgroundColor="transparent" />
       <ErrorBoundary>
         <SettingsGate>
           <NavigationContainer linking={linking}>
@@ -93,7 +94,6 @@ class App extends React.Component {
   public render() {
     return (
       <SafeAreaProvider>
-        <StatusBar barStyle="dark-content" translucent backgroundColor="transparent" />
         <InnerApp />
       </SafeAreaProvider>
     );

--- a/src/screens/CollectionChangelogScreen.tsx
+++ b/src/screens/CollectionChangelogScreen.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import moment from "moment";
 import { useSelector } from "react-redux";
 import { FlatList, View } from "react-native";
-import { Divider, Appbar, Text, List, useTheme } from "react-native-paper";
+import { Divider, Text, List, useTheme } from "react-native-paper";
 import { useNavigation, RouteProp } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 
@@ -16,6 +16,7 @@ import Container from "../widgets/Container";
 import Menu from "../widgets/Menu";
 import { Title } from "../widgets/Typography";
 import NotFound from "../widgets/NotFound";
+import AppbarAction from "../widgets/AppbarAction";
 
 import { defaultColor } from "../helpers";
 import { DefaultNavigationProp, RootStackParamList } from "../RootStackParamList";
@@ -122,7 +123,7 @@ function RightAction(props: { colUid: string }) {
       visible={showMenu}
       onDismiss={() => setShowMenu(false)}
       anchor={(
-        <Appbar.Action icon="dots-vertical" accessibilityLabel="Menu" onPress={() => setShowMenu(true)} />
+        <AppbarAction icon="dots-vertical" accessibilityLabel="Menu" onPress={() => setShowMenu(true)} />
       )}
     >
       <Menu.Item icon="pencil" title="Edit"

--- a/src/screens/CollectionEditScreen.tsx
+++ b/src/screens/CollectionEditScreen.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 import { useSelector } from "react-redux";
 import { TextInput as NativeTextInput } from "react-native";
-import { HelperText, Appbar, Paragraph } from "react-native-paper";
+import { HelperText, Paragraph } from "react-native-paper";
 import { useNavigation, RouteProp, useNavigationState, CommonActions } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 
@@ -20,6 +20,7 @@ import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import ErrorOrLoadingDialog from "../widgets/ErrorOrLoadingDialog";
 import NotFound from "../widgets/NotFound";
 import FormButton from "../widgets/FormButton";
+import AppbarAction from "../widgets/AppbarAction";
 
 import { useLoading, defaultColor } from "../helpers";
 import { DefaultNavigationProp, RootStackParamList } from "../RootStackParamList";
@@ -220,7 +221,7 @@ function RightAction(props: { colUid: string | undefined }) {
 
   return (
     <React.Fragment>
-      <Appbar.Action
+      <AppbarAction
         icon="delete"
         accessibilityLabel="Delete collection"
         onPress={() => {

--- a/src/screens/CollectionMembersScreen.tsx
+++ b/src/screens/CollectionMembersScreen.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import * as Etebase from "etebase";
 import { useSelector, useDispatch } from "react-redux";
 import { View } from "react-native";
-import { Avatar, List, Appbar, Paragraph, useTheme } from "react-native-paper";
+import { Avatar, List, Paragraph, useTheme } from "react-native-paper";
 import { useNavigation, RouteProp } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 
@@ -20,6 +20,7 @@ import LoadingIndicator from "../widgets/LoadingIndicator";
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import ErrorDialog from "../widgets/ErrorDialog";
 import NotFound from "../widgets/NotFound";
+import AppbarAction from "../widgets/AppbarAction";
 import CollectionMemberAddDialog from "../components/CollectionMemberAddDialog";
 import { RootStackParamList } from "../RootStackParamList";
 
@@ -196,7 +197,7 @@ export default function CollectionMembersScreen(props: PropsType) {
 function RightAction(props: { onClick: () => void }) {
   return (
     <>
-      <Appbar.Action
+      <AppbarAction
         icon="account-plus"
         accessibilityLabel="Add member"
         onPress={() => {

--- a/src/screens/NoteEditScreen.tsx
+++ b/src/screens/NoteEditScreen.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 import * as Etebase from "etebase";
 import { View, ViewProps, KeyboardAvoidingView, Platform } from "react-native";
-import { Appbar, Paragraph, useTheme } from "react-native-paper";
+import { Paragraph, useTheme } from "react-native-paper";
 import { useNavigation, RouteProp } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { useDebouncedCallback } from "use-debounce";
@@ -22,6 +22,7 @@ import LoadingIndicator from "../widgets/LoadingIndicator";
 import Menu from "../widgets/Menu";
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import NotFound from "../widgets/NotFound";
+import AppbarAction from "../widgets/AppbarAction";
 import { fontFamilies } from "../helpers";
 import { RootStackParamList } from "../RootStackParamList";
 import { canShare, shareItem } from "../import-export";
@@ -253,14 +254,14 @@ function RightAction({ viewMode, setViewMode, onSave, onEdit, onDelete, onShare,
 
   return (
     <View style={{ flexDirection: "row" }}>
-      <Appbar.Action icon={viewMode ? "pencil" : "eye"} accessibilityLabel="View mode" onPress={() => {
+      <AppbarAction icon={viewMode ? "pencil" : "eye"} accessibilityLabel="View mode" onPress={() => {
         setViewMode(!viewMode);
       }} />
       <Menu
         visible={showMenu}
         onDismiss={() => setShowMenu(false)}
         anchor={(
-          <Appbar.Action icon="dots-vertical" accessibilityLabel="Menu" onPress={() => setShowMenu(true)} />
+          <AppbarAction icon="dots-vertical" accessibilityLabel="Menu" onPress={() => setShowMenu(true)} />
         )}
       >
         <Menu.Item icon="pencil" title="Edit Properties"

--- a/src/screens/NoteListScreen.tsx
+++ b/src/screens/NoteListScreen.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 import moment from "moment";
 import { StyleSheet, FlatList, View, Platform } from "react-native";
-import { Appbar, List, FAB } from "react-native-paper";
+import { List, FAB } from "react-native-paper";
 import { useNavigation, useFocusEffect, RouteProp } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { useSelector, useDispatch } from "react-redux";
@@ -18,6 +18,7 @@ import { useCredentials } from "../credentials";
 import Menu from "../widgets/Menu";
 import MenuItem from "../widgets/MenuItem";
 import NotFound from "../widgets/NotFound";
+import AppbarAction from "../widgets/AppbarAction";
 import { DefaultNavigationProp, RootStackParamList } from "../RootStackParamList";
 import { useTheme } from "../theme";
 
@@ -214,7 +215,7 @@ function RightAction(props: RightActionPropsType) {
 
   return (
     <View style={{ flexDirection: "row" }}>
-      <Appbar.Action icon="sync" accessibilityLabel="Sync"
+      <AppbarAction icon="sync" accessibilityLabel="Sync"
         disabled={isSyncing}
         onPress={() => {
           setShowMenu(false);
@@ -225,7 +226,7 @@ function RightAction(props: RightActionPropsType) {
         visible={showMenu}
         onDismiss={() => setShowMenu(false)}
         anchor={(
-          <Appbar.Action icon="dots-vertical" accessibilityLabel="Menu" onPress={() => setShowMenu(true)} />
+          <AppbarAction icon="dots-vertical" accessibilityLabel="Menu" onPress={() => setShowMenu(true)} />
         )}
       >
         <Menu

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -19,7 +19,6 @@ const mainColors = {
 
 export const LightTheme: Theme = {
   ...PaperLightTheme,
-  mode: "exact",
   colors: {
     ...PaperLightTheme.colors,
     ...mainColors,
@@ -33,7 +32,6 @@ export const LightTheme: Theme = {
 
 export const DarkTheme: Theme = {
   ...PaperDarkTheme,
-  mode: "exact",
   colors: {
     ...PaperDarkTheme.colors,
     ...mainColors,

--- a/src/widgets/AppbarAction.tsx
+++ b/src/widgets/AppbarAction.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { Appbar } from "react-native-paper";
+import { useTheme } from "../theme";
+
+
+export default function AppbarAction(props: React.ComponentProps<typeof Appbar.Action>) {
+  const { color, ...rest } = props;
+  const theme = useTheme();
+  const iconColor = color ?? ((theme.dark) ? theme.colors.text : undefined);
+
+  return (
+    <Appbar.Action color={iconColor} {...rest} />
+  );
+}

--- a/src/widgets/MenuButton.tsx
+++ b/src/widgets/MenuButton.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { useNavigation } from "@react-navigation/native";
 import { DrawerNavigationProp } from "@react-navigation/drawer";
-import { Appbar } from "react-native-paper";
+import AppbarAction from "./AppbarAction";
 
 const MenuButton = React.memo(function MenuButton() {
   const navigation = useNavigation() as DrawerNavigationProp<any>;
   return (
-    <Appbar.Action icon="menu" accessibilityLabel="Main menu" onPress={() => navigation.openDrawer()} />
+    <AppbarAction icon="menu" accessibilityLabel="Main menu" onPress={() => navigation.openDrawer()} />
   );
 });
 


### PR DESCRIPTION
The previous dark theme was too bright in my opinion. This actually only changes the color of the Header Bar to a shade of grey, and is the default behavior of React Native Paper.

![Screenshot_2021-01-24-18-33-00-554](https://user-images.githubusercontent.com/76261501/105692577-dd27a880-5efe-11eb-9a44-5c90a7a93a55.jpeg)
![Screenshot_2021-01-24-18-33-47-295](https://user-images.githubusercontent.com/76261501/105692586-def16c00-5efe-11eb-926f-5d77957c1a05.jpeg)

I find now that the app lacks touches of the primary color though. Maybe we could get rid of the accent color and only use the primary?

Tested on web Firefox Linux
Tested on native Android