### PR TITLE
Limit form button's width on large screens

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 
 import { View, TextInput as NativeTextInput } from "react-native";
-import { Switch, Button, HelperText, Paragraph, TouchableRipple } from "react-native-paper";
+import { Switch, HelperText, Paragraph, TouchableRipple } from "react-native-paper";
 
 
 import ExternalLink from "../widgets/ExternalLink";
@@ -13,6 +13,7 @@ import TextInput from "../widgets/TextInput";
 
 import * as C from "../constants";
 import PasswordInput from "../widgets/PasswordInput";
+import FormButton from "../widgets/FormButton";
 
 interface FormErrors {
   username?: string;
@@ -150,12 +151,11 @@ export default function LoginForm(props: PropsType) {
           <React.Fragment />
         </HelperText>
 
-        <Button
-          mode="contained"
+        <FormButton
           onPress={onSubmit}
         >
           Log In
-        </Button>
+        </FormButton>
       </View>
     </>
   );

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -175,6 +175,7 @@ export const fontFamilies = Platform.select({
 
 // These are taken from https://material.io/design/layout/responsive-layout-grid.html#breakpoints
 const deviceBreakpoints = {
+  tabletPortrait: 600,
   tabletLandscape: 960,
 };
 

--- a/src/screens/CollectionEditScreen.tsx
+++ b/src/screens/CollectionEditScreen.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 import { useSelector } from "react-redux";
 import { TextInput as NativeTextInput } from "react-native";
-import { HelperText, Button, Appbar, Paragraph } from "react-native-paper";
+import { HelperText, Appbar, Paragraph } from "react-native-paper";
 import { useNavigation, RouteProp, useNavigationState, CommonActions } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 
@@ -19,6 +19,7 @@ import Container from "../widgets/Container";
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
 import ErrorOrLoadingDialog from "../widgets/ErrorOrLoadingDialog";
 import NotFound from "../widgets/NotFound";
+import FormButton from "../widgets/FormButton";
 
 import { useLoading, defaultColor } from "../helpers";
 import { DefaultNavigationProp, RootStackParamList } from "../RootStackParamList";
@@ -194,13 +195,12 @@ export default function CollectionEditScreen(props: PropsType) {
 
         {collectionColorBox}
 
-        <Button
-          mode="contained"
+        <FormButton
           disabled={loading}
           onPress={onSave}
         >
           {loading ? "Loading…" : "Save"}
-        </Button>
+        </FormButton>
       </Container>
     </ScrollView>
   );

--- a/src/screens/NotePropertiesScreen.tsx
+++ b/src/screens/NotePropertiesScreen.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 import { useSelector } from "react-redux";
 import { View } from "react-native";
-import { HelperText, Button, TouchableRipple } from "react-native-paper";
+import { HelperText, TouchableRipple } from "react-native-paper";
 import { useNavigation, RouteProp } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { Item } from "etebase";
@@ -22,6 +22,7 @@ import ErrorOrLoadingDialog from "../widgets/ErrorOrLoadingDialog";
 import Select from "../widgets/Select";
 import TextInputWithIcon from "../widgets/TextInputWithIcon";
 import NotFound from "../widgets/NotFound";
+import FormButton from "../widgets/FormButton";
 
 import { useLoading, NoteMetadata } from "../helpers";
 import { RootStackParamList } from "../RootStackParamList";
@@ -215,13 +216,12 @@ export default function NotePropertiesScreen(props: PropsType) {
           </HelperText>
         </View>
 
-        <Button
-          mode="contained"
+        <FormButton
           disabled={loading}
           onPress={onSave}
         >
           {loading ? "Loading…" : "Save"}
-        </Button>
+        </FormButton>
       </Container>
     </ScrollView>
   );

--- a/src/screens/SignupScreen.tsx
+++ b/src/screens/SignupScreen.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import * as Etebase from "etebase";
 
 import { View, TextInput as NativeTextInput, Linking } from "react-native";
-import { Switch, Button, Text, HelperText, Paragraph, TouchableRipple } from "react-native-paper";
+import { Switch, Text, HelperText, Paragraph, TouchableRipple } from "react-native-paper";
 
 import { Headline } from "../widgets/Typography";
 import ScrollView from "../widgets/ScrollView";
@@ -15,6 +15,7 @@ import TextInput from "../widgets/TextInput";
 import PasswordInput from "../widgets/PasswordInput";
 import Alert from "../widgets/Alert";
 import Row from "../widgets/Row";
+import FormButton from "../widgets/FormButton";
 
 import { useAsyncDispatch } from "../store";
 
@@ -258,14 +259,13 @@ export default React.memo(function SignupScreen() {
             Please make sure you remember your password, as it can't be recovered if lost!
           </Alert>
 
-          <Button
-            mode="contained"
+          <FormButton
             onPress={onSubmit}
             disabled={loading}
             loading={loading}
           >
             Signup
-          </Button>
+          </FormButton>
         </View>
       </Container>
     </ScrollView>

--- a/src/widgets/FormButton.tsx
+++ b/src/widgets/FormButton.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { Button } from "react-native-paper";
+import { useDeviceBreakpoint } from "../helpers";
+
+type PropsType = Omit<React.ComponentProps<typeof Button>, "mode">;
+
+export default function FormButton(props: PropsType) {
+  const { children, style, ...rest } = props;
+  const breakpoint = useDeviceBreakpoint("tabletPortrait");
+  const alignSelf = (breakpoint) ? "flex-end" : undefined;
+
+  return (
+    <Button
+      mode="contained"
+      style={[{ alignSelf }, style]}
+      {...rest}
+    >
+      {children}
+    </Button>
+  );
+}


### PR DESCRIPTION
The button was too present at full width when using a large screen. I set a `minWidth` so it's noticeable enough even if the label is small.

![Screenshot_2021-01-26-10-47-31-797](https://user-images.githubusercontent.com/76261501/105829117-3d345280-5fc4-11eb-8be6-e827cfa0c2ab.jpeg)

Tested on web Firefox Linux
Tested on native Android