### PR TITLE
Improve selected menu item style

### DIFF
--- a/src/screens/NoteListScreen.tsx
+++ b/src/screens/NoteListScreen.tsx
@@ -16,6 +16,7 @@ import { performSync, setSettings } from "../store/actions";
 import { useCredentials } from "../credentials";
 
 import Menu from "../widgets/Menu";
+import MenuItem from "../widgets/MenuItem";
 import NotFound from "../widgets/NotFound";
 import { DefaultNavigationProp, RootStackParamList } from "../RootStackParamList";
 import { useTheme } from "../theme";
@@ -175,7 +176,6 @@ function RightAction(props: RightActionPropsType) {
   const [showSortMenu, setShowSortMenu_] = React.useState(false);
   const syncDispatch = useDispatch();
   const isSyncing = useSelector((state: StoreState) => state.syncCount) > 0;
-  const selecetdStyle = { color: "green" };
   const viewSettings = useSelector((state: StoreState) => state.settings.viewSettings);
   const navigation = useNavigation<DefaultNavigationProp>();
   const { colUid } = props;
@@ -240,11 +240,9 @@ function RightAction(props: RightActionPropsType) {
             />
           )}
         >
-          <Menu.Item icon="sort-alphabetical" title="Name"
+          <MenuItem icon="sort-alphabetical" title="Name"
             disabled={isSyncing}
-            titleStyle={
-              (viewSettings.sortBy === "name") ? selecetdStyle : undefined
-            }
+            active={viewSettings.sortBy === "name"}
             onPress={() => {
               setShowSortMenu(false);
               syncDispatch(setSettings({
@@ -255,11 +253,9 @@ function RightAction(props: RightActionPropsType) {
               }));
             }}
           />
-          <Menu.Item icon="sort-numeric" title="Modification time"
+          <MenuItem icon="sort-numeric" title="Modification time"
             disabled={isSyncing}
-            titleStyle={
-              (viewSettings.sortBy === "mtime") ? selecetdStyle : undefined
-            }
+            active={viewSettings.sortBy === "mtime"}
             onPress={() => {
               setShowSortMenu(false);
               syncDispatch(setSettings({
@@ -272,7 +268,7 @@ function RightAction(props: RightActionPropsType) {
           />
         </Menu>
         {colUid && (
-          <Menu.Item icon="notebook" title="Manage Notebook"
+          <MenuItem icon="notebook" title="Manage Notebook"
             disabled={isSyncing}
             onPress={() => {
               setShowMenu(false);

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -6,6 +6,9 @@ export interface Theme extends PaperTheme {
   colors: PaperTheme["colors"] & {
     accentText: string;
     onAccent: string;
+    active: string;
+    activeIcon: string;
+    activeBackground: string;
   };
 }
 
@@ -22,6 +25,9 @@ export const LightTheme: Theme = {
     ...mainColors,
     accentText: Color(mainColors.accent).darken(0.2).rgb().string(),
     onAccent: "#FFFFFF",
+    active: Color(mainColors.accent).darken(0.4).rgb().string(),
+    activeIcon: Color(mainColors.accent).darken(0.2).rgb().string(),
+    activeBackground: Color(mainColors.accent).alpha(0.12).rgb().string(),
   },
 };
 
@@ -33,6 +39,9 @@ export const DarkTheme: Theme = {
     ...mainColors,
     accentText: Color(mainColors.accent).lighten(0.4).rgb().string(),
     onAccent: "#000000",
+    active: Color(mainColors.accent).lighten(0.4).rgb().string(),
+    activeIcon: mainColors.accent,
+    activeBackground: Color(mainColors.accent).alpha(0.12).rgb().string(),
   },
 };
 

--- a/src/widgets/MenuItem.tsx
+++ b/src/widgets/MenuItem.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { ViewStyle } from "react-native";
+import { Menu } from "react-native-paper";
+import { useTheme } from "../theme";
+
+type PropsType = Omit<React.ComponentProps<typeof Menu.Item>, "icon" | "theme" | "style"> & {
+  style?: ViewStyle;
+  icon?: string;
+  active?: boolean;
+};
+
+export default function MenuItem(props: PropsType) {
+  const { active, disabled, icon, style, ...rest } = props;
+  const { colors } = useTheme();
+  
+  return (
+    <Menu.Item
+      disabled={disabled}
+      icon={(icon) ? ({ color, size }) => <MaterialCommunityIcons name={icon} size={size} color={(active && !disabled) ? colors.activeIcon : color} /> : undefined}
+      theme={(active) ? { colors: { text: colors.active } } : undefined}
+      style={(active) ? [{ backgroundColor: colors.activeBackground }, style] : style}
+      {...rest}
+    />
+  );
+}


### PR DESCRIPTION
I actually could do it directly with `Menu.Item`, I hadn't realized I could provide my own icon component.

![image](https://user-images.githubusercontent.com/76261501/105992774-ccfdfd80-60a5-11eb-8235-12c7cf4edb2d.png)

Tested on web Firefox Linux
Tested on native Android