### PR TITLE
Make AnchorButton look like a dropdown anchor

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -3,7 +3,7 @@
 
 import * as React from "react";
 import { TextInput as NativeTextInput, Linking } from "react-native";
-import { List, HelperText, Switch, Button } from "react-native-paper";
+import { List, HelperText, Switch } from "react-native-paper";
 import { useDispatch, useSelector } from "react-redux";
 import * as Updates from "expo-updates";
 
@@ -26,31 +26,11 @@ import { startTask, enforcePasswordRules } from "../helpers";
 import { useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import Alert from "../widgets/Alert";
+import AnchorButton from "../widgets/AnchorButton";
 import FontSelector from "../widgets/FontSelector";
 import Select from "../widgets/Select";
 import { RootStackParamList } from "../RootStackParamList";
 import { useTheme } from "../theme";
-
-type AnchorButtonProps = {
-  onPress: () => void;
-  children: React.ReactNode;
-};
-
-function AnchorButton(props: AnchorButtonProps) {
-  const { children, onPress } = props; 
-  const theme = useTheme();
-
-  return (
-    <Button
-      mode="contained"
-      color={theme.colors.accent}
-      labelStyle={{ color: theme.colors.onAccent }}
-      onPress={onPress}
-    >
-      {children}
-    </Button>
-  );
-}
 
 interface DialogPropsType {
   visible: boolean;
@@ -199,7 +179,12 @@ function DarkModePreferenceSelector() {
             dispatch(setSettings({ theme: selected as typeof darkModePreference }));
           }}
           anchor={(
-            <AnchorButton onPress={() => setDarkModePreferenceOpen(true)}>{prettyName[darkModePreference]}</AnchorButton>
+            <AnchorButton
+              open={selectDarkModeOpen}
+              onPress={() => setDarkModePreferenceOpen(true)}
+            >
+              {prettyName[darkModePreference]}
+            </AnchorButton>
           )}
         />
       }
@@ -240,7 +225,12 @@ function FontSizePreferenceSelector() {
             dispatch(setSettings({ fontSize: selected as typeof fontSizePreference }));
           }}
           anchor={(
-            <AnchorButton onPress={() => setFontSizePreferenceOpen(true)}>{fontSizePreference && prettyName[fontSizePreference]}</AnchorButton>
+            <AnchorButton
+              open={selectFontSizeOpen}
+              onPress={() => setFontSizePreferenceOpen(true)}
+            >
+              {fontSizePreference && prettyName[fontSizePreference]}
+            </AnchorButton>
           )}
         />
       }
@@ -359,7 +349,12 @@ function ViewModePreferenceSelector() {
             }));
           }}
           anchor={(
-            <AnchorButton onPress={() => setViewModePreferenceOpen(true)}>{prettyName[defaultViewMode]}</AnchorButton>
+            <AnchorButton
+              open={selectViewModeOpen}
+              onPress={() => setViewModePreferenceOpen(true)}
+            >
+              {prettyName[defaultViewMode]}
+            </AnchorButton>
           )}
         />
       }

--- a/src/widgets/AnchorButton.tsx
+++ b/src/widgets/AnchorButton.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { Button } from "react-native-paper";
+import { useTheme } from "../theme";
+
+type TypeProps = {
+  open: boolean;
+  onPress: () => void;
+  children: React.ReactNode;
+};
+
+export default function AnchorButton(props: TypeProps) {
+  const { children, onPress, open } = props; 
+  const theme = useTheme();
+
+  return (
+    <Button
+      mode="contained"
+      color={theme.colors.accent}
+      labelStyle={{ color: theme.colors.onAccent }}
+      onPress={onPress}
+      icon={(open) ? "menu-up" : "menu-down"}
+      contentStyle={{ flexDirection: "row-reverse" }}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/widgets/FontSelector.tsx
+++ b/src/widgets/FontSelector.tsx
@@ -3,9 +3,8 @@
 
 import * as React from "react";
 import { ViewProps } from "react-native";
-import { Button } from "react-native-paper";
 import { fontFamilies, FontFamilyKey } from "../helpers";
-import { useTheme } from "../theme";
+import AnchorButton from "./AnchorButton";
 import Menu from "./Menu";
 
 interface PropsType extends ViewProps {
@@ -18,7 +17,6 @@ interface PropsType extends ViewProps {
 
 export default function FontSelector(inProps: React.PropsWithChildren<PropsType>) {
   const { visible, selected, onDismiss, onChange, onOpen, ...props } = inProps;
-  const theme = useTheme();
   const prettyName = {
     regular: "Normal",
     monospace: "Monospace",
@@ -30,14 +28,12 @@ export default function FontSelector(inProps: React.PropsWithChildren<PropsType>
       visible={visible}
       onDismiss={onDismiss}
       anchor={(
-        <Button
-          mode="contained"
-          color={theme.colors.accent}
-          labelStyle={{ color: theme.colors.onAccent }}
+        <AnchorButton
+          open={visible}
           onPress={onOpen}
         >
           {selected && prettyName[selected]}
-        </Button>
+        </AnchorButton>
       )}
       {...props}
     >


### PR DESCRIPTION
Shows a down arrow at the right of the button label.

![Screenshot_2021-01-27-14-42-03-761](https://user-images.githubusercontent.com/76261501/105999433-f7ec4f80-60ad-11eb-9a74-6ef4aa7ce998.jpeg)

Tested on web Firefox Linux
Tested on native Android