### PR TITLE
Update useAppStateCb event listener when etebase changes

### DIFF
--- a/src/RootNavigator.tsx
+++ b/src/RootNavigator.tsx
@@ -42,13 +42,13 @@ export default React.memo(function RootNavigator() {
   const etebase = useCredentials();
 
   // Sync app when it goes to background
-  useAppStateCb((_foreground) => {
+  useAppStateCb(React.useCallback((_foreground) => {
     if (etebase) {
       // FIXME: We should only sync when moving to foreground if haven't in X minutes
       const syncManager = SyncManager.getManager(etebase);
       dispatch(performSync(syncManager.sync()));
     }
-  });
+  }, [etebase]));
 
   return (
     <>

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -138,7 +138,7 @@ export function useAppStateCb(cb: (foreground: boolean) => void) {
     return () => {
       AppState.removeEventListener("change", onChange);
     };
-  }, []);
+  }, [cb]);
 
   return appState;
 }


### PR DESCRIPTION
Since `etebase`'s value wasn't updated in the event listener after `RootNavigator` was created, the app was not syncing when coming back to foreground after login (`etebase === null`) and was trying to sync when coming back to foreground after logout  (`etebase !== null`), until the app was restarted.

This fixes #138.

Tested on native Android