### PR TITLE
Add hover effect to DrawerItem with Clickable

### DIFF
--- a/src/widgets/Clickable.tsx
+++ b/src/widgets/Clickable.tsx
@@ -5,6 +5,7 @@ type ChildProps = {
 };
 
 type PropsType = {
+  applyToChild?: boolean;
   renderChild: (props: ChildProps) => React.ReactElement;
 };
 

--- a/src/widgets/Clickable.web.tsx
+++ b/src/widgets/Clickable.web.tsx
@@ -7,12 +7,22 @@ type ChildProps = {
 };
 
 type PropsType = {
+  applyToChild?: boolean;
   renderChild: (props: ChildProps) => React.ReactElement;
 };
 
 export default function Clickable(props: PropsType) {
-  const { renderChild } = props;
+  const { applyToChild, renderChild } = props;
   const theme = useTheme();
+  const className = `state ${theme.dark ? "dark" : "light"}`;
 
-  return renderChild({ className: `state ${theme.dark ? "dark" : "light"}` });
+  if (applyToChild) {
+    return renderChild({ className });
+  }
+
+  return (
+    <div className={className}>
+      {renderChild({})}
+    </div>
+  );
 }

--- a/src/widgets/DrawerItem.tsx
+++ b/src/widgets/DrawerItem.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { DrawerItem as BaseDrawerItem } from "@react-navigation/drawer";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { useTheme } from "../theme";
+import Clickable from "./Clickable";
 
 type PropsType = Omit<React.ComponentProps<typeof BaseDrawerItem>, "icon"> & {
   disabled?: boolean;
@@ -12,17 +13,22 @@ export default function DrawerItem(props: PropsType) {
   const { disabled, icon, onPress, to, ...rest } = props;
   const { colors } = useTheme();
 
-  return <BaseDrawerItem
-    inactiveTintColor={(disabled) ? colors.disabled : colors.text}
-    icon={({ size }) => (
-      <MaterialCommunityIcons
-        name={icon}
-        color={(disabled) ? colors.disabled : colors.inactiveIcon}
-        size={size}
+  return <Clickable
+    renderChild={(props) => (
+      <BaseDrawerItem
+        {...props}
+        inactiveTintColor={(disabled) ? colors.disabled : colors.text}
+        icon={({ size }) => (
+          <MaterialCommunityIcons
+            name={icon}
+            color={(disabled) ? colors.disabled : colors.inactiveIcon}
+            size={size}
+          />
+        )}
+        to={(disabled) ? "" : to}
+        onPress={(disabled) ? () => null : onPress}
+        {...rest}
       />
     )}
-    to={(disabled) ? "" : to}
-    onPress={(disabled) ? () => null : onPress}
-    {...rest}
   />;
 }

--- a/src/widgets/Link.web.tsx
+++ b/src/widgets/Link.web.tsx
@@ -31,6 +31,7 @@ export default function Link(props: PropsType) {
 
   return (
     <Clickable
+      applyToChild
       renderChild={(props) => (
         <a
           {...props}


### PR DESCRIPTION
We can't set `className` to components that are not `HTMLElement`s so they have to be wrapped in a `div`. That means only the hover effect works, not the focus effect.

Tested on web Firefox Linux
Tested on native Android