### PR TITLE
issue#176: document `yarn add expo` for devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ Find more information about setting up the development environments here https:/
 
 Before you can build the App from source, you need to make sure you have `yarn` and `node` installed.
 
-- Clone this repository `git clone https://github.com/mrichtsfeld/etesync-notes.git`
+- Clone this repository `git clone https://github.com/etesync/etesync-notes.git`
 - Enter the newly created folder `cd etesync-notes`
 - Run `yarn` and wait until all of the deps are installed
 
 ## Run the Web App
 
 - Install expo `npm install -g expo-cli`
+- Run `yarn add expo`
 - Run `yarn web`
 
 ## Run the iOS App (OS X only)


### PR DESCRIPTION
(WIP) things I think would be helpful to cover:
1. [x] call out [`yarn add expo` that tasn explained](https://github.com/etesync/etesync-notes/issues/176#issuecomment-890487286)
1. [ ] should probably actually explain that `yarn add expo`'s corresponding
package.json,yarn.lock changes should be ignored and not accidentally
committed.
1. [ ] explain if/should you have started a etebase backend (and if so, link to the right repo's instructions)
1. [ ] should explain how to setup a fake account/backend (so you're not local-testing against your personal prod data)
